### PR TITLE
Add facility for a user provided (state-global) native error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Alias for `lua_pushcfunction`.
 Alias for `lua_pushcclosure`.
 
 
+### `lua_atnativeerror(L, func)`
+
+Sets a function to be called if a native JavaScript error is thrown across a lua pcall.
+The function will be run as if it were a message handler (see https://www.lua.org/manual/5.3/manual.html#2.3).
+
+
 ### `b = lua_isproxy(p, L)`
 
 Returns a boolean `b` indicating whether `p` is a proxy (See `lua_toproxy`).

--- a/src/lapi.js
+++ b/src/lapi.js
@@ -36,6 +36,12 @@ const lua_atpanic = function(L, panicf) {
     return old;
 };
 
+const lua_atnativeerror = function(L, errorf) {
+    let old = L.l_G.atnativeerror;
+    L.l_G.atnativeerror = errorf;
+    return old;
+};
+
 // Return value for idx on stack
 const index2addr = function(L, idx) {
     let ci = L.ci;
@@ -1104,6 +1110,7 @@ module.exports.index2addr_           = index2addr_;
 module.exports.lua_absindex          = lua_absindex;
 module.exports.lua_arith             = lua_arith;
 module.exports.lua_atpanic           = lua_atpanic;
+module.exports.lua_atnativeerror     = lua_atnativeerror;
 module.exports.lua_call              = lua_call;
 module.exports.lua_callk             = lua_callk;
 module.exports.lua_checkstack        = lua_checkstack;

--- a/src/lstate.js
+++ b/src/lstate.js
@@ -66,6 +66,7 @@ class global_State {
         this.mainthread = L;
         this.l_registry = new lobject.TValue(CT.LUA_TNIL, null);
         this.panic = null;
+        this.atnativeerror = null;
         this.version = null;
         this.tmname = new Array(ltm.TMS.TM_N);
         this.mt = new Array(LUA_NUMTAGS);

--- a/src/lua.js
+++ b/src/lua.js
@@ -95,6 +95,7 @@ module.exports.LUA_DIRSEP              = defs.LUA_DIRSEP;
 module.exports.lua_absindex            = lapi.lua_absindex;
 module.exports.lua_arith               = lapi.lua_arith;
 module.exports.lua_atpanic             = lapi.lua_atpanic;
+module.exports.lua_atnativeerror       = lapi.lua_atnativeerror;
 module.exports.lua_call                = lapi.lua_call;
 module.exports.lua_callk               = lapi.lua_callk;
 module.exports.lua_checkstack          = lapi.lua_checkstack;


### PR DESCRIPTION
This PR adds a function `lua_atnativeerror`.
Similar to `lua_atpanic`, this registers a function to be called in a rare error condition.

Previously we just pushed the native error object as a lightuserdata.


This function will be used by fengari-interop to wrap native error objects into something inspectable by lua code