### PR TITLE
src/lvm.js: Fix TODO for tointeger

### DIFF
--- a/src/lobject.js
+++ b/src/lobject.js
@@ -523,7 +523,7 @@ const intarith = function(L, op, v1, v2) {
         case defs.LUA_OPSUB:  return (v1 - v2)|0;
         case defs.LUA_OPMUL:  return (v1 * v2)|0;
         case defs.LUA_OPMOD:  return (v1 - Math.floor(v1 / v2) * v2)|0; // % semantic on negative numbers is different in js
-        case defs.LUA_OPIDIV: return (v1 / v2)|0;
+        case defs.LUA_OPIDIV: return Math.floor(v1 / v2)|0;
         case defs.LUA_OPBAND: return (v1 & v2);
         case defs.LUA_OPBOR:  return (v1 | v2);
         case defs.LUA_OPBXOR: return (v1 ^ v2);
@@ -543,7 +543,7 @@ const numarith = function(L, op, v1, v2) {
         case defs.LUA_OPMUL:  return v1 * v2;
         case defs.LUA_OPDIV:  return v1 / v2;
         case defs.LUA_OPPOW:  return Math.pow(v1, v2);
-        case defs.LUA_OPIDIV: return (v1 / v2);
+        case defs.LUA_OPIDIV: return Math.floor(v1 / v2);
         case defs.LUA_OPUNM:  return -v1;
         case defs.LUA_OPMOD:  return v1 % v2;
         default: assert(0);

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -531,6 +531,7 @@ const intarith = function(L, op, v1, v2) {
         case defs.LUA_OPSHR:  return (v1 >> v2);
         case defs.LUA_OPUNM:  return (0 - v1)|0;
         case defs.LUA_OPBNOT: return (~0 ^ v1);
+        default: assert(0);
     }
 };
 
@@ -545,6 +546,7 @@ const numarith = function(L, op, v1, v2) {
         case defs.LUA_OPIDIV: return (v1 / v2);
         case defs.LUA_OPUNM:  return -v1;
         case defs.LUA_OPMOD:  return v1 % v2;
+        default: assert(0);
     }
 };
 

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -713,8 +713,8 @@ const luaV_equalobj = function(L, t1, t2) {
         if (t1.ttnov() !== t2.ttnov() || t1.ttnov() !== CT.LUA_TNUMBER)
             return 0; /* only numbers can be equal with different variants */
         else { /* two numbers with different variants */
-            /* compare them as integers */
-            return Math.floor(t1.value) === Math.floor(t2.value) ? 1 : 0; // TODO: tointeger
+            let i1, i2; /* compare them as integers */
+            return (((i1 = luaV_tointeger(t1, 0)) !== false) && ((i2 = luaV_tointeger(t2, 0)) !== false) && (i1 === i2)) ? 1 : 0;
         }
     }
 

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -713,8 +713,8 @@ const luaV_equalobj = function(L, t1, t2) {
         if (t1.ttnov() !== t2.ttnov() || t1.ttnov() !== CT.LUA_TNUMBER)
             return 0; /* only numbers can be equal with different variants */
         else { /* two numbers with different variants */
-            let i1, i2; /* compare them as integers */
-            return (((i1 = luaV_tointeger(t1, 0)) !== false) && ((i2 = luaV_tointeger(t2, 0)) !== false) && (i1 === i2)) ? 1 : 0;
+            /* OPTIMIZATION: instead of calling luaV_tointeger we can just let JS do the comparison */
+            return (t1.value === t2.value) ? 1 : 0;
         }
     }
 


### PR DESCRIPTION
Fixes `0.983 == 0` == true

Followup commits fix bugs exposed once float<=>integer comparison is correct.