### PR TITLE
global LUA_USE_ASSERT to remove asserts with webpack

### DIFF
--- a/src/defs.js
+++ b/src/defs.js
@@ -4,10 +4,7 @@
 const luaconf = require('./luaconf.js');
 const llimit  = require('./llimit.js');
 
-let LUA_USE_ASSERT = true;
-module.exports.LUA_USE_ASSERT = LUA_USE_ASSERT;
-
-if (LUA_USE_ASSERT) var assert  = require('assert');
+const assert  = require('assert');
 
 // To avoid charCodeAt everywhere
 const char = [];

--- a/src/defs.js
+++ b/src/defs.js
@@ -1,9 +1,13 @@
 /*jshint esversion: 6 */
 "use strict";
 
-const assert  = require('assert');
 const luaconf = require('./luaconf.js');
 const llimit  = require('./llimit.js');
+
+let LUA_USE_ASSERT = true;
+module.exports.LUA_USE_ASSERT = LUA_USE_ASSERT;
+
+if (LUA_USE_ASSERT) var assert  = require('assert');
 
 // To avoid charCodeAt everywhere
 const char = [];
@@ -135,7 +139,7 @@ class lua_Debug {
 }
 
 const to_jsstring = function(value, from, to) {
-    assert(Array.isArray(value), "jsstring expect a array of bytes");
+    if (LUA_USE_ASSERT) assert(Array.isArray(value), "jsstring expect a array of bytes");
 
     let u0, u1, u2, u3, u4, u5;
     let idx = 0;
@@ -181,7 +185,7 @@ const to_jsstring = function(value, from, to) {
 const to_luastring_cache = {};
 
 const to_luastring = function(str, cache, maxBytesToWrite) {
-    assert(typeof str === "string", "to_luastring expect a js string");
+    if (LUA_USE_ASSERT) assert(typeof str === "string", "to_luastring expect a js string");
 
     if (cache) {
         let cached = to_luastring_cache[str];

--- a/src/lapi.js
+++ b/src/lapi.js
@@ -2,7 +2,7 @@
 
 const defs      = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert = require('assert');
+const assert = require('assert');
 
 const ldebug    = require('./ldebug.js');
 const ldo       = require('./ldo.js');
@@ -48,17 +48,17 @@ const index2addr = function(L, idx) {
     let ci = L.ci;
     if (idx > 0) {
         let o = ci.funcOff + idx;
-        if (defs.LUA_USE_ASSERT) assert(idx <= ci.top - (ci.funcOff + 1), "unacceptable index");
+        if (LUA_USE_ASSERT) assert(idx <= ci.top - (ci.funcOff + 1), "unacceptable index");
         if (o >= L.top) return lobject.luaO_nilobject;
         else return L.stack[o];
     } else if (idx > defs.LUA_REGISTRYINDEX) {
-        if (defs.LUA_USE_ASSERT) assert(idx !== 0 && -idx <= L.top, "invalid index");
+        if (LUA_USE_ASSERT) assert(idx !== 0 && -idx <= L.top, "invalid index");
         return L.stack[L.top + idx];
     } else if (idx === defs.LUA_REGISTRYINDEX) {
         return L.l_G.l_registry;
     } else { /* upvalues */
         idx = defs.LUA_REGISTRYINDEX - idx;
-        if (defs.LUA_USE_ASSERT) assert(idx <= MAXUPVAL + 1, "upvalue index too large");
+        if (LUA_USE_ASSERT) assert(idx <= MAXUPVAL + 1, "upvalue index too large");
         if (ci.func.ttislcf()) /* light C function? */
             return lobject.luaO_nilobject; /* it has no upvalues */
         else {
@@ -72,17 +72,17 @@ const index2addr_ = function(L, idx) {
     let ci = L.ci;
     if (idx > 0) {
         let o = ci.funcOff + idx;
-        if (defs.LUA_USE_ASSERT) assert(idx <= ci.top - (ci.funcOff + 1), "unacceptable index");
+        if (LUA_USE_ASSERT) assert(idx <= ci.top - (ci.funcOff + 1), "unacceptable index");
         if (o >= L.top) return null;
         else return o;
     } else if (idx > defs.LUA_REGISTRYINDEX) {
-        if (defs.LUA_USE_ASSERT) assert(idx !== 0 && -idx <= L.top, "invalid index");
+        if (LUA_USE_ASSERT) assert(idx !== 0 && -idx <= L.top, "invalid index");
         return L.top + idx;
     } else if (idx === defs.LUA_REGISTRYINDEX) {
         return null;
     } else { /* upvalues */
         idx = defs.LUA_REGISTRYINDEX - idx;
-        if (defs.LUA_USE_ASSERT) assert(idx <= MAXUPVAL + 1, "upvalue index too large");
+        if (LUA_USE_ASSERT) assert(idx <= MAXUPVAL + 1, "upvalue index too large");
         if (ci.func.ttislcf()) /* light C function? */
             return null; /* it has no upvalues */
         else {
@@ -97,9 +97,9 @@ const lua_checkstack = function(L, n) {
 
 const lua_xmove = function(from, to, n) {
     if (from === to) return;
-    if (defs.LUA_USE_ASSERT) assert(n < (from.top - from.ci.funcOff), "not enough elements in the stack");
-    if (defs.LUA_USE_ASSERT) assert(from.l_G === to.l_G, "moving among independent states");
-    if (defs.LUA_USE_ASSERT) assert(to.ci.top - to.top >= n, "stack overflow");
+    if (LUA_USE_ASSERT) assert(n < (from.top - from.ci.funcOff), "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(from.l_G === to.l_G, "moving among independent states");
+    if (LUA_USE_ASSERT) assert(to.ci.top - to.top >= n, "stack overflow");
 
     from.top -= n;
     for (let i = 0; i < n; i++) {
@@ -129,7 +129,7 @@ const lua_pushvalue = function(L, idx) {
     L.stack[L.top] = index2addr(L, idx);
 
     L.top++;
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 };
 
 const lua_settop = function(L, idx) {
@@ -139,7 +139,7 @@ const lua_settop = function(L, idx) {
             L.stack[L.top++] = new TValue(CT.LUA_TNIL, null);
         L.top = func + 1 + idx;
     } else {
-        if (defs.LUA_USE_ASSERT) assert(-(idx + 1) <= L.top - (func + 1), "invalid new top");
+        if (LUA_USE_ASSERT) assert(-(idx + 1) <= L.top - (func + 1), "invalid new top");
         let newtop = L.top + idx + 1; /* 'subtract' index (index is negative) */
         while (L.top > newtop)
             delete L.stack[--L.top];
@@ -167,8 +167,8 @@ const lua_rotate = function(L, idx, n) {
     let p = index2addr(L, idx);
     let pIdx = index2addr_(L, idx);
 
-    if (defs.LUA_USE_ASSERT) assert(p !== lobject.luaO_nilobject && idx > defs.LUA_REGISTRYINDEX, "index not in the stack");
-    if (defs.LUA_USE_ASSERT) assert((n >= 0 ? n : -n) <= (L.top - idx), "invalid 'n'");
+    if (LUA_USE_ASSERT) assert(p !== lobject.luaO_nilobject && idx > defs.LUA_REGISTRYINDEX, "index not in the stack");
+    if (LUA_USE_ASSERT) assert((n >= 0 ? n : -n) <= (L.top - idx), "invalid 'n'");
 
     let m = n >= 0 ? L.top - 1 - n : pIdx - n - 1;  /* end of prefix */
 
@@ -203,39 +203,39 @@ const lua_replace = function(L, idx) {
 const lua_pushnil = function(L) {
     L.stack[L.top++] = new TValue(CT.LUA_TNIL, null);
 
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 };
 
 const lua_pushnumber = function(L, n) {
-    if (defs.LUA_USE_ASSERT) assert(typeof n === "number");
+    if (LUA_USE_ASSERT) assert(typeof n === "number");
 
     L.stack[L.top++] = new TValue(CT.LUA_TNUMFLT, n);
 
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 };
 
 const lua_pushinteger = function(L, n) {
-    if (defs.LUA_USE_ASSERT) assert(typeof n === "number" && (n|0) === n);
+    if (LUA_USE_ASSERT) assert(typeof n === "number" && (n|0) === n);
 
     L.stack[L.top++] = new TValue(CT.LUA_TNUMINT, n);
 
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 };
 
 const lua_pushlstring = function(L, s, len) {
-    if (defs.LUA_USE_ASSERT) assert(Array.isArray(s), "lua_pushlstring expects array of byte");
-    if (defs.LUA_USE_ASSERT) assert(typeof len === "number");
+    if (LUA_USE_ASSERT) assert(Array.isArray(s), "lua_pushlstring expects array of byte");
+    if (LUA_USE_ASSERT) assert(typeof len === "number");
 
     let ts = new TValue(CT.LUA_TLNGSTR, lstring.luaS_bless(L, s.slice(0, len)));
     L.stack[L.top++] = ts;
 
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 
     return ts.value;
 };
 
 const lua_pushstring = function (L, s) {
-    if (defs.LUA_USE_ASSERT) assert(Array.isArray(s) || s === undefined || s === null, "lua_pushstring expects array of byte");
+    if (LUA_USE_ASSERT) assert(Array.isArray(s) || s === undefined || s === null, "lua_pushstring expects array of byte");
 
     if (s === undefined || s === null)
         L.stack[L.top] = new TValue(CT.LUA_TNIL, null);
@@ -244,23 +244,23 @@ const lua_pushstring = function (L, s) {
     }
 
     L.top++;
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 
     return s;
 };
 
 const lua_pushvfstring = function (L, fmt, argp) {
-    if (defs.LUA_USE_ASSERT) assert(Array.isArray(fmt));
+    if (LUA_USE_ASSERT) assert(Array.isArray(fmt));
     return lobject.luaO_pushvfstring(L, fmt, argp);
 };
 
 const lua_pushfstring = function (L, fmt, ...argp) {
-    if (defs.LUA_USE_ASSERT) assert(Array.isArray(fmt));
+    if (LUA_USE_ASSERT) assert(Array.isArray(fmt));
     return lobject.luaO_pushvfstring(L, fmt, argp);
 };
 
 const lua_pushliteral = function (L, s) {
-    if (defs.LUA_USE_ASSERT) assert(typeof s === "string" || s === undefined || s === null, "lua_pushliteral expects a JS string");
+    if (LUA_USE_ASSERT) assert(typeof s === "string" || s === undefined || s === null, "lua_pushliteral expects a JS string");
 
     if (s === undefined || s === null)
         L.stack[L.top] = new TValue(CT.LUA_TNIL, null);
@@ -270,20 +270,20 @@ const lua_pushliteral = function (L, s) {
     }
 
     L.top++;
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 
     return s;
 };
 
 const lua_pushcclosure = function(L, fn, n) {
-    if (defs.LUA_USE_ASSERT) assert(typeof fn === "function");
-    if (defs.LUA_USE_ASSERT) assert(typeof n === "number");
+    if (LUA_USE_ASSERT) assert(typeof fn === "function");
+    if (LUA_USE_ASSERT) assert(typeof n === "number");
 
     if (n === 0)
         L.stack[L.top] = new TValue(CT.LUA_TLCF, fn);
     else {
-        if (defs.LUA_USE_ASSERT) assert(n < L.top - L.ci.funcOff, "not enough elements in the stack");
-        if (defs.LUA_USE_ASSERT) assert(n <= MAXUPVAL, "upvalue index too large");
+        if (LUA_USE_ASSERT) assert(n < L.top - L.ci.funcOff, "not enough elements in the stack");
+        if (LUA_USE_ASSERT) assert(n <= MAXUPVAL, "upvalue index too large");
 
         let cl = new CClosure(L, fn, n);
 
@@ -297,7 +297,7 @@ const lua_pushcclosure = function(L, fn, n) {
     }
 
     L.top++;
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 };
 
 const lua_pushjsclosure = lua_pushcclosure;
@@ -311,18 +311,18 @@ const lua_pushjsfunction = lua_pushcfunction;
 const lua_pushboolean = function(L, b) {
     L.stack[L.top++] = new TValue(CT.LUA_TBOOLEAN, b ? true : false);
 
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 };
 
 const lua_pushlightuserdata = function(L, p) {
     L.stack[L.top++] = new TValue(CT.LUA_TLIGHTUSERDATA, p);
 
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 };
 
 const lua_pushthread = function(L) {
     L.stack[L.top++] = new TValue(CT.LUA_TTHREAD, L);
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 
     return L.l_G.mainthread === L;
 };
@@ -339,11 +339,11 @@ const lua_pushglobaltable = function(L) {
 ** t[k] = value at the top of the stack (where 'k' is a string)
 */
 const auxsetstr = function(L, t, k) {
-    if (defs.LUA_USE_ASSERT) assert(Array.isArray(k), "key must be an array of bytes");
+    if (LUA_USE_ASSERT) assert(Array.isArray(k), "key must be an array of bytes");
 
     let str = new TValue(CT.LUA_TLNGSTR, lstring.luaS_new(L, k));
 
-    if (defs.LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
 
     L.stack[L.top++] = str;
     lvm.settable(L, t, L.stack[L.top - 1], L.stack[L.top - 2]);
@@ -357,13 +357,13 @@ const lua_setglobal = function(L, name) {
 };
 
 const lua_setmetatable = function(L, objindex) {
-    if (defs.LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
     let mt;
     let obj = index2addr(L, objindex);
     if (L.stack[L.top - 1].ttisnil())
         mt = null;
     else {
-        if (defs.LUA_USE_ASSERT) assert(L.stack[L.top - 1].ttistable(), "table expected");
+        if (LUA_USE_ASSERT) assert(L.stack[L.top - 1].ttistable(), "table expected");
         mt = L.stack[L.top - 1].value;
     }
 
@@ -384,7 +384,7 @@ const lua_setmetatable = function(L, objindex) {
 };
 
 const lua_settable = function(L, idx) {
-    if (defs.LUA_USE_ASSERT) assert(2 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(2 < L.top - L.ci.funcOff, "not enough elements in the stack");
 
     let t = index2addr(L, idx);
     lvm.settable(L, t, L.stack[L.top - 2], L.stack[L.top - 1]);
@@ -396,11 +396,11 @@ const lua_setfield = function(L, idx, k) {
 };
 
 const lua_seti = function(L, idx, n) {
-    if (defs.LUA_USE_ASSERT) assert(typeof n === "number" && (n|0) === n);
-    if (defs.LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(typeof n === "number" && (n|0) === n);
+    if (LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
     let t = index2addr(L, idx);
     L.stack[L.top++] = new TValue(CT.LUA_TNUMINT, n);
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     lvm.settable(L, t, L.stack[L.top - 1], L.stack[L.top - 2]);
     /* pop value and key */
     delete L.stack[--L.top];
@@ -408,9 +408,9 @@ const lua_seti = function(L, idx, n) {
 };
 
 const lua_rawset = function(L, idx) {
-    if (defs.LUA_USE_ASSERT) assert(2 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(2 < L.top - L.ci.funcOff, "not enough elements in the stack");
     let o = index2addr(L, idx);
-    if (defs.LUA_USE_ASSERT) assert(o.ttistable(), "table expected");
+    if (LUA_USE_ASSERT) assert(o.ttistable(), "table expected");
     let k = L.stack[L.top - 2];
     let v = L.stack[L.top - 1];
     if (v.ttisnil()) {
@@ -423,17 +423,17 @@ const lua_rawset = function(L, idx) {
 };
 
 const lua_rawseti = function(L, idx, n) {
-    if (defs.LUA_USE_ASSERT) assert(2 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(2 < L.top - L.ci.funcOff, "not enough elements in the stack");
     let o = index2addr(L, idx);
-    if (defs.LUA_USE_ASSERT) assert(o.ttistable(), "table expected");
+    if (LUA_USE_ASSERT) assert(o.ttistable(), "table expected");
     ltable.luaH_setint(o.value, n, L.stack[L.top - 1]);
     delete L.stack[--L.top];
 };
 
 const lua_rawsetp = function(L, idx, p) {
-    if (defs.LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
     let o = index2addr(L, idx);
-    if (defs.LUA_USE_ASSERT) assert(L, o.ttistable(), "table expected");
+    if (LUA_USE_ASSERT) assert(L, o.ttistable(), "table expected");
     let k = new TValue(CT.LUA_TLIGHTUSERDATA, p);
     let v = L.stack[L.top - 1];
     if (v.ttisnil()) {
@@ -450,12 +450,12 @@ const lua_rawsetp = function(L, idx, p) {
 */
 
 const auxgetstr = function(L, t, k) {
-    if (defs.LUA_USE_ASSERT) assert(Array.isArray(k), "key must be an array of bytes");
+    if (LUA_USE_ASSERT) assert(Array.isArray(k), "key must be an array of bytes");
 
     let str = new TValue(CT.LUA_TLNGSTR, lstring.luaS_new(L, k));
 
     L.stack[L.top++] = str;
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     lvm.gettable(L, t, L.stack[L.top - 1], L.top - 1);
 
     return L.stack[L.top - 1].ttnov();
@@ -464,27 +464,27 @@ const auxgetstr = function(L, t, k) {
 const lua_rawgeti = function(L, idx, n) {
     let t = index2addr(L, idx);
 
-    if (defs.LUA_USE_ASSERT) assert(t.ttistable(), "table expected");
+    if (LUA_USE_ASSERT) assert(t.ttistable(), "table expected");
 
     L.stack[L.top++] = ltable.luaH_getint(t.value, n);
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 
     return L.stack[L.top - 1].ttnov();
 };
 
 const lua_rawgetp = function(L, idx, p) {
     let t = index2addr(L, idx);
-    if (defs.LUA_USE_ASSERT) assert(t.ttistable(), "table expected");
+    if (LUA_USE_ASSERT) assert(t.ttistable(), "table expected");
     let k = new TValue(CT.LUA_TLIGHTUSERDATA, p);
     L.stack[L.top++] = ltable.luaH_get(t.value, k);
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     return L.stack[L.top - 1].ttnov();
 };
 
 const lua_rawget = function(L, idx) {
     let t = index2addr(L, idx);
 
-    if (defs.LUA_USE_ASSERT) assert(t.ttistable(t), "table expected");
+    if (LUA_USE_ASSERT) assert(t.ttistable(t), "table expected");
 
     L.stack[L.top - 1] = ltable.luaH_get(t.value, L.stack[L.top - 1]);
 
@@ -496,7 +496,7 @@ const lua_createtable = function(L, narray, nrec) {
     let t = new lobject.TValue(CT.LUA_TTABLE, ltable.luaH_new(L));
     L.stack[L.top++] = t;
 
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 };
 
 const luaS_newudata = function(L, size) {
@@ -513,7 +513,7 @@ const lua_newuserdata = function(L, size) {
     let u = luaS_newudata(L, size);
     L.stack[L.top++] = new lobject.TValue(CT.LUA_TUSERDATA, u);
 
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 
     return u.data;
 };
@@ -557,7 +557,7 @@ const lua_getupvalue = function(L, funcindex, n) {
 
 const lua_setupvalue = function(L, funcindex, n) {
     let fi = index2addr(L, funcindex);
-    if (defs.LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
     let aux = aux_upvalue(L, fi, n);
     if (aux) {
         let name = aux.name;
@@ -597,7 +597,7 @@ const lua_getmetatable = function(L, objindex) {
 
     if (mt !== null && mt !== undefined) {
         L.stack[L.top++] = new TValue(CT.LUA_TTABLE, mt);
-        if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+        if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
         res = true;
     }
 
@@ -606,10 +606,10 @@ const lua_getmetatable = function(L, objindex) {
 
 const lua_getuservalue = function(L, idx) {
     let o = index2addr(L, idx);
-    if (defs.LUA_USE_ASSERT) assert(L, o.ttisfulluserdata(), "full userdata expected");
+    if (LUA_USE_ASSERT) assert(L, o.ttisfulluserdata(), "full userdata expected");
     let uv = o.value.uservalue;
     L.stack[L.top++] = new TValue(uv.type, uv.value);
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     return L.stack[L.top - 1].ttnov();
 };
 
@@ -624,10 +624,10 @@ const lua_getfield = function(L, idx, k) {
 };
 
 const lua_geti = function(L, idx, n) {
-    if (defs.LUA_USE_ASSERT) assert(typeof n === "number" && (n|0) === n);
+    if (LUA_USE_ASSERT) assert(typeof n === "number" && (n|0) === n);
     let t = index2addr(L, idx);
     L.stack[L.top++] = new TValue(CT.LUA_TNUMINT, n);
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     lvm.gettable(L, t, L.stack[L.top - 1], L.top - 1);
     return L.stack[L.top - 1].ttnov();
 };
@@ -758,7 +758,7 @@ const lua_isproxy = function(p, L) {
 /* Use 'create_proxy' helper function so that 'L' is not in scope */
 const create_proxy = function(G, type, value) {
     let proxy = function(L) {
-        if (defs.LUA_USE_ASSERT) assert(L instanceof lstate.lua_State && G === L.l_G, "must be from same global state");
+        if (LUA_USE_ASSERT) assert(L instanceof lstate.lua_State && G === L.l_G, "must be from same global state");
         L.stack[L.top++] = new TValue(type, value);
     };
     seen.set(proxy, G);
@@ -783,7 +783,7 @@ const lua_compare = function(L, index1, index2, op) {
             case defs.LUA_OPEQ: i = lvm.luaV_equalobj(L, o1, o2); break;
             case defs.LUA_OPLT: i = lvm.luaV_lessthan(L, o1, o2); break;
             case defs.LUA_OPLE: i = lvm.luaV_lessequal(L, o1, o2); break;
-            default: if (defs.LUA_USE_ASSERT) assert(false, "invalid option");
+            default: if (LUA_USE_ASSERT) assert(false, "invalid option");
         }
     }
 
@@ -794,7 +794,7 @@ const lua_stringtonumber = function(L, s) {
     let tv = lobject.luaO_str2num(s);
     if (tv) {
         L.stack[L.top++] = tv;
-        if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+        if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
         return s.length;
     }
     return 0;
@@ -814,7 +814,7 @@ const lua_type = function(L, idx) {
 };
 
 const lua_typename = function(L, t) {
-    if (defs.LUA_USE_ASSERT) assert(CT.LUA_TNONE <= t && t < CT.LUA_NUMTAGS, "invalid tag");
+    if (LUA_USE_ASSERT) assert(CT.LUA_TNONE <= t && t < CT.LUA_NUMTAGS, "invalid tag");
     return ltm.ttypename(t);
 };
 
@@ -881,9 +881,9 @@ const lua_rawequal = function(L, index1, index2) {
 
 const lua_arith = function(L, op) {
     if (op !== defs.LUA_OPUNM && op !== defs.LUA_OPBNOT)
-        if (defs.LUA_USE_ASSERT) assert(2 < L.top - L.ci.funcOff, "not enough elements in the stack");  /* all other operations expect two operands */
+        if (LUA_USE_ASSERT) assert(2 < L.top - L.ci.funcOff, "not enough elements in the stack");  /* all other operations expect two operands */
     else {  /* for unary operations, add fake 2nd operand */
-        if (defs.LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
+        if (LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
         L.stack[L.top++] = L.stack[L.top - 1];
     }
     /* first operand at top - 2, second at top - 1; result go to top - 2 */
@@ -896,8 +896,8 @@ const lua_arith = function(L, op) {
 */
 
 const lua_load = function(L, reader, data, chunkname, mode) {
-    if (defs.LUA_USE_ASSERT) assert(Array.isArray(chunkname), "lua_load expect an array of byte as chunkname");
-    if (defs.LUA_USE_ASSERT) assert(mode ? Array.isArray(mode) : true, "lua_load expect an array of byte as mode");
+    if (LUA_USE_ASSERT) assert(Array.isArray(chunkname), "lua_load expect an array of byte as chunkname");
+    if (LUA_USE_ASSERT) assert(mode ? Array.isArray(mode) : true, "lua_load expect an array of byte as mode");
     if (!chunkname) chunkname = [defs.char["?"]];
     let z = new lzio.ZIO(L, reader, data);
     let status = ldo.luaD_protectedparser(L, z, chunkname, mode);
@@ -914,7 +914,7 @@ const lua_load = function(L, reader, data, chunkname, mode) {
 };
 
 const lua_dump = function(L, writer, data, strip) {
-    if (defs.LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
     let o = L.stack[L.top -1];
     if (o.ttisLclosure())
         return ldump.luaU_dump(L, o.value.p, writer, data, strip);
@@ -926,18 +926,18 @@ const lua_status = function(L) {
 };
 
 const lua_setuservalue = function(L, idx) {
-    if (defs.LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
     let o = index2addr(L, idx);
-    if (defs.LUA_USE_ASSERT) assert(L, o.ttisfulluserdata(), "full userdata expected");
+    if (LUA_USE_ASSERT) assert(L, o.ttisfulluserdata(), "full userdata expected");
     o.value.uservalue.setfrom(L.stack[L.top - 1]);
     delete L.stack[--L.top];
 };
 
 const lua_callk = function(L, nargs, nresults, ctx, k) {
-    if (defs.LUA_USE_ASSERT) assert(k === null || !(L.ci.callstatus & lstate.CIST_LUA), "cannot use continuations inside hooks");
-    if (defs.LUA_USE_ASSERT) assert(nargs + 1 < L.top - L.ci.funcOff, "not enough elements in the stack");
-    if (defs.LUA_USE_ASSERT) assert(L.status === TS.LUA_OK, "cannot do calls on non-normal thread");
-    if (defs.LUA_USE_ASSERT) assert(nargs === defs.LUA_MULTRET || (L.ci.top - L.top >= nargs - nresults, "results from function overflow current stack size"));
+    if (LUA_USE_ASSERT) assert(k === null || !(L.ci.callstatus & lstate.CIST_LUA), "cannot use continuations inside hooks");
+    if (LUA_USE_ASSERT) assert(nargs + 1 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(L.status === TS.LUA_OK, "cannot do calls on non-normal thread");
+    if (LUA_USE_ASSERT) assert(nargs === defs.LUA_MULTRET || (L.ci.top - L.top >= nargs - nresults, "results from function overflow current stack size"));
 
     let func = L.top - (nargs + 1);
     if (k !== null && L.nny === 0) { /* need to prepare continuation? */
@@ -957,9 +957,9 @@ const lua_call = function(L, n, r) {
 };
 
 const lua_pcallk = function(L, nargs, nresults, errfunc, ctx, k) {
-    if (defs.LUA_USE_ASSERT) assert(nargs + 1 < L.top - L.ci.funcOff, "not enough elements in the stack");
-    if (defs.LUA_USE_ASSERT) assert(L.status === TS.LUA_OK, "cannot do calls on non-normal thread");
-    if (defs.LUA_USE_ASSERT) assert(nargs === defs.LUA_MULTRET || (L.ci.top - L.top >= nargs - nresults, "results from function overflow current stack size"));
+    if (LUA_USE_ASSERT) assert(nargs + 1 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(L.status === TS.LUA_OK, "cannot do calls on non-normal thread");
+    if (LUA_USE_ASSERT) assert(nargs === defs.LUA_MULTRET || (L.ci.top - L.top >= nargs - nresults, "results from function overflow current stack size"));
 
     let c = {
         func: null,
@@ -1014,17 +1014,17 @@ const lua_pcall = function(L, n, r, f) {
 */
 
 const lua_error = function(L) {
-    if (defs.LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
     ldebug.luaG_errormsg(L);
 };
 
 const lua_next = function(L, idx) {
     let t = index2addr(L, idx);
-    if (defs.LUA_USE_ASSERT) assert(t.ttistable(), "table expected");
+    if (LUA_USE_ASSERT) assert(t.ttistable(), "table expected");
     let more = ltable.luaH_next(L, t.value, L.top - 1);
     if (more) {
         L.top++;
-        if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+        if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
         return 1;
     } else {
         L.top--;
@@ -1033,26 +1033,26 @@ const lua_next = function(L, idx) {
 };
 
 const lua_concat = function(L, n) {
-    if (defs.LUA_USE_ASSERT) assert(n < L.top - L.ci.funcOff, "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(n < L.top - L.ci.funcOff, "not enough elements in the stack");
     if (n >= 2)
         lvm.luaV_concat(L, n);
     else if (n === 0) {
         L.stack[L.top++] = new TValue(CT.LUA_TLNGSTR, lstring.luaS_newliteral(L, []));
-        if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+        if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     }
 };
 
 const lua_len = function(L, idx) {
     let t = index2addr(L, idx);
     lvm.luaV_objlen(L, L.top++, t);
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
 };
 
 const getupvalref = function(L, fidx, n, pf) {
     let fi = index2addr(L, fidx);
-    if (defs.LUA_USE_ASSERT) assert(fi.ttisLclosure(), "Lua function expected");
+    if (LUA_USE_ASSERT) assert(fi.ttisLclosure(), "Lua function expected");
     let f = fi.value;
-    if (defs.LUA_USE_ASSERT) assert(1 <= n && n <= f.p.upvalues.length, "invalid upvalue index");
+    if (LUA_USE_ASSERT) assert(1 <= n && n <= f.p.upvalues.length, "invalid upvalue index");
     return {
         closure: f,
         upval: f.upvals[n - 1],
@@ -1068,11 +1068,11 @@ const lua_upvalueid = function(L, fidx, n) {
         }
         case CT.LUA_TCCL: {  /* C closure */
             let f = fi.value;
-            if (defs.LUA_USE_ASSERT) assert(1 <= n && n <= f.nupvalues, "invalid upvalue index");
+            if (LUA_USE_ASSERT) assert(1 <= n && n <= f.nupvalues, "invalid upvalue index");
             return f.upvalue[n - 1];
         }
         default: {
-            if (defs.LUA_USE_ASSERT) assert(false, "closure expected");
+            if (LUA_USE_ASSERT) assert(false, "closure expected");
             return null;
         }
     }

--- a/src/lcode.js
+++ b/src/lcode.js
@@ -1,15 +1,15 @@
 "use strict";
 
-const assert   = require('assert');
-
 const defs     = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert   = require('assert');
+
 const llex     = require('./llex.js');
 const lobject  = require('./lobject.js');
 const lopcodes = require('./lopcodes.js');
 const lparser  = require('./lparser.js');
 const lstring  = require('./lstring.js');
 const ltable   = require('./ltable.js');
-const ltm      = require('./ltm.js');
 const lvm      = require('./lvm.js');
 
 const CT       = defs.CT;
@@ -137,7 +137,7 @@ const getjump = function(fs, pc) {
 const fixjump = function(fs, pc, dest) {
     let jmp = fs.f.code[pc];
     let offset = dest - (pc + 1);
-    assert(dest !== NO_JUMP);
+    if (defs.LUA_USE_ASSERT) assert(dest !== NO_JUMP);
     if (Math.abs(offset) > lopcodes.MAXARG_sBx)
         llex.luaX_syntaxerror(fs.ls, defs.to_luastring("control structure too long", true));
     lopcodes.SETARG_sBx(jmp, offset);
@@ -291,7 +291,7 @@ const luaK_patchlist = function(fs, list, target) {
     if (target === fs.pc)  /* 'target' is current position? */
         luaK_patchtohere(fs, list);  /* add list to pending jumps */
     else {
-        assert(target < fs.pc);
+        if (defs.LUA_USE_ASSERT) assert(target < fs.pc);
         patchlistaux(fs, list, target, lopcodes.NO_REG, target);
     }
 };
@@ -305,7 +305,7 @@ const luaK_patchclose = function(fs, list, level) {
     level++;  /* argument is +1 to reserve 0 as non-op */
     for (; list !== NO_JUMP; list = getjump(fs, list)) {
         let ins = fs.f.code[list];
-        assert(ins.opcode === OpCodesI.OP_JMP && (ins.A === 0 || ins.A >= level));
+        if (defs.LUA_USE_ASSERT) assert(ins.opcode === OpCodesI.OP_JMP && (ins.A === 0 || ins.A >= level));
         lopcodes.SETARG_A(ins, level);
     }
 };
@@ -328,10 +328,10 @@ const luaK_code = function(fs, i) {
 ** of parameters versus opcode.)
 */
 const luaK_codeABC = function(fs, o, a, b, c) {
-    assert(lopcodes.getOpMode(o) === lopcodes.iABC);
-    assert(lopcodes.getBMode(o) !== lopcodes.OpArgN || b === 0);
-    assert(lopcodes.getCMode(o) !== lopcodes.OpArgN || c === 0);
-    assert(a <= lopcodes.MAXARG_A && b <= lopcodes.MAXARG_B && c <= lopcodes.MAXARG_C);
+    if (defs.LUA_USE_ASSERT) assert(lopcodes.getOpMode(o) === lopcodes.iABC);
+    if (defs.LUA_USE_ASSERT) assert(lopcodes.getBMode(o) !== lopcodes.OpArgN || b === 0);
+    if (defs.LUA_USE_ASSERT) assert(lopcodes.getCMode(o) !== lopcodes.OpArgN || c === 0);
+    if (defs.LUA_USE_ASSERT) assert(a <= lopcodes.MAXARG_A && b <= lopcodes.MAXARG_B && c <= lopcodes.MAXARG_C);
     return luaK_code(fs, lopcodes.CREATE_ABC(o, a, b, c));
 };
 
@@ -339,9 +339,9 @@ const luaK_codeABC = function(fs, o, a, b, c) {
 ** Format and emit an 'iABx' instruction.
 */
 const luaK_codeABx = function(fs, o, a, bc) {
-    assert(lopcodes.getOpMode(o) === lopcodes.iABx || lopcodes.getOpMode(o) === lopcodes.iAsBx);
-    assert(lopcodes.getCMode(o) === lopcodes.OpArgN);
-    assert(a <= lopcodes.MAXARG_A && bc <= lopcodes.MAXARG_Bx);
+    if (defs.LUA_USE_ASSERT) assert(lopcodes.getOpMode(o) === lopcodes.iABx || lopcodes.getOpMode(o) === lopcodes.iAsBx);
+    if (defs.LUA_USE_ASSERT) assert(lopcodes.getCMode(o) === lopcodes.OpArgN);
+    if (defs.LUA_USE_ASSERT) assert(a <= lopcodes.MAXARG_A && bc <= lopcodes.MAXARG_Bx);
     return luaK_code(fs, lopcodes.CREATE_ABx(o, a, bc));
 };
 
@@ -353,7 +353,7 @@ const luaK_codeAsBx = function(fs,o,A,sBx) {
 ** Emit an "extra argument" instruction (format 'iAx')
 */
 const codeextraarg = function(fs, a) {
-    assert(a <= lopcodes.MAXARG_Ax);
+    if (defs.LUA_USE_ASSERT) assert(a <= lopcodes.MAXARG_Ax);
     return luaK_code(fs, lopcodes.CREATE_Ax(OpCodesI.OP_EXTRAARG, a));
 };
 
@@ -400,7 +400,7 @@ const luaK_reserveregs = function(fs, n) {
 const freereg = function(fs, reg) {
     if (!lopcodes.ISK(reg) && reg >= fs.nactvar) {
         fs.freereg--;
-        assert(reg === fs.freereg);
+        if (defs.LUA_USE_ASSERT) assert(reg === fs.freereg);
     }
 };
 
@@ -520,7 +520,7 @@ const luaK_setreturns = function(fs, e, nresults) {
         lopcodes.SETARG_A(pc, fs.freereg);
         luaK_reserveregs(fs, 1);
     }
-    else assert(nresults === defs.LUA_MULTRET);
+    else if (defs.LUA_USE_ASSERT) assert(nresults === defs.LUA_MULTRET);
 };
 
 const luaK_setmultret = function(fs, e) {
@@ -541,7 +541,7 @@ const luaK_setoneret = function(fs, e) {
     let ek = lparser.expkind;
     if (e.k === ek.VCALL) {  /* expression is an open function call? */
         /* already returns 1 value */
-        assert(getinstruction(fs, e).C === 2);
+        if (defs.LUA_USE_ASSERT) assert(getinstruction(fs, e).C === 2);
         e.k = ek.VNONRELOC;  /* result has fixed position */
         e.u.info = getinstruction(fs, e).A;
     } else if (e.k === ek.VVARARG) {
@@ -573,7 +573,7 @@ const luaK_dischargevars = function(fs, e) {
                 freereg(fs, e.u.ind.t);
                 op = OpCodesI.OP_GETTABLE;
             } else {
-                assert(e.u.ind.vt === ek.VUPVAL);
+                if (defs.LUA_USE_ASSERT) assert(e.u.ind.vt === ek.VUPVAL);
                 op = OpCodesI.OP_GETTABUP;  /* 't' is in an upvalue */
             }
             e.u.info = luaK_codeABC(fs, op, 0, e.u.ind.t, e.u.ind.idx);
@@ -632,7 +632,7 @@ const discharge2reg = function(fs, e, reg) {
             break;
         }
         default: {
-            assert(e.k === ek.VJMP);
+            if (defs.LUA_USE_ASSERT) assert(e.k === ek.VJMP);
             return;  /* nothing to do... */
         }
     }
@@ -819,7 +819,7 @@ const luaK_self = function(fs, e, key) {
 */
 const negatecondition = function(fs, e) {
     let pc = getjumpcontrol(fs, e.u.info);
-    assert(lopcodes.testTMode(pc.opcode) && pc.opcode !== OpCodesI.OP_TESTSET && pc.opcode !== OpCodesI.OP_TEST);
+    if (defs.LUA_USE_ASSERT) assert(lopcodes.testTMode(pc.opcode) && pc.opcode !== OpCodesI.OP_TESTSET && pc.opcode !== OpCodesI.OP_TEST);
     lopcodes.SETARG_A(pc, !(pc.A));
 };
 
@@ -936,7 +936,7 @@ const codenot = function(fs, e) {
 */
 const luaK_indexed = function(fs, t, k) {
     let ek = lparser.expkind;
-    assert(!hasjumps(t) && (lparser.vkisinreg(t.k) || t.k === ek.VUPVAL));
+    if (defs.LUA_USE_ASSERT) assert(!hasjumps(t) && (lparser.vkisinreg(t.k) || t.k === ek.VUPVAL));
     t.u.ind.t = t.u.info;  /* register or upvalue index */
     t.u.ind.idx = luaK_exp2RK(fs, k);  /* R/K index for key */
     t.u.ind.vt = (t.k === ek.VUPVAL) ? ek.VUPVAL : ek.VLOCAL;
@@ -1029,7 +1029,7 @@ const codecomp = function(fs, opr, e1, e2) {
     if (e1.k === ek.VK)
         rk1 = lopcodes.RKASK(e1.u.info);
     else {
-        assert(e1.k === ek.VNONRELOC);
+        if (defs.LUA_USE_ASSERT) assert(e1.k === ek.VNONRELOC);
         rk1 = e1.u.info;
     }
 
@@ -1121,14 +1121,14 @@ const luaK_posfix = function(fs, op, e1, e2, line) {
     let ek = lparser.expkind;
     switch (op) {
         case BinOpr.OPR_AND: {
-            assert(e1.t === NO_JUMP);  /* list closed by 'luK_infix' */
+            if (defs.LUA_USE_ASSERT) assert(e1.t === NO_JUMP);  /* list closed by 'luK_infix' */
             luaK_dischargevars(fs, e2);
             e2.f = luaK_concat(fs, e2.f, e1.f);
             e1.to(e2);
             break;
         }
         case BinOpr.OPR_OR: {
-            assert(e1.f === NO_JUMP);  /* list closed by 'luK_infix' */
+            if (defs.LUA_USE_ASSERT) assert(e1.f === NO_JUMP);  /* list closed by 'luK_infix' */
             luaK_dischargevars(fs, e2);
             e2.t = luaK_concat(fs, e2.t, e1.t);
             e1.to(e2);
@@ -1138,7 +1138,7 @@ const luaK_posfix = function(fs, op, e1, e2, line) {
             let ins = getinstruction(fs, e2);
             luaK_exp2val(fs, e2);
             if (e2.k === ek.VRELOCABLE && ins.opcode === OpCodesI.OP_CONCAT) {
-                assert(e1.u.info === ins.B - 1);
+                if (defs.LUA_USE_ASSERT) assert(e1.u.info === ins.B - 1);
                 freeexp(fs, e1);
                 lopcodes.SETARG_B(ins, e1.u.info);
                 e1.k = ek.VRELOCABLE; e1.u.info = e2.u.info;
@@ -1184,7 +1184,7 @@ const luaK_fixline = function(fs, line) {
 const luaK_setlist = function(fs, base, nelems, tostore) {
     let c =  (nelems - 1)/lopcodes.LFIELDS_PER_FLUSH + 1;
     let b = (tostore === defs.LUA_MULTRET) ? 0 : tostore;
-    assert(tostore !== 0 && tostore <= lopcodes.LFIELDS_PER_FLUSH);
+    if (defs.LUA_USE_ASSERT) assert(tostore !== 0 && tostore <= lopcodes.LFIELDS_PER_FLUSH);
     if (c <= lopcodes.MAXARG_C)
         luaK_codeABC(fs, OpCodesI.OP_SETLIST, base, b, c);
     else if (c <= lopcodes.MAXARG_Ax) {

--- a/src/lcode.js
+++ b/src/lcode.js
@@ -2,7 +2,7 @@
 
 const defs     = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert   = require('assert');
+const assert   = require('assert');
 
 const llex     = require('./llex.js');
 const lobject  = require('./lobject.js');
@@ -137,7 +137,7 @@ const getjump = function(fs, pc) {
 const fixjump = function(fs, pc, dest) {
     let jmp = fs.f.code[pc];
     let offset = dest - (pc + 1);
-    if (defs.LUA_USE_ASSERT) assert(dest !== NO_JUMP);
+    if (LUA_USE_ASSERT) assert(dest !== NO_JUMP);
     if (Math.abs(offset) > lopcodes.MAXARG_sBx)
         llex.luaX_syntaxerror(fs.ls, defs.to_luastring("control structure too long", true));
     lopcodes.SETARG_sBx(jmp, offset);
@@ -291,7 +291,7 @@ const luaK_patchlist = function(fs, list, target) {
     if (target === fs.pc)  /* 'target' is current position? */
         luaK_patchtohere(fs, list);  /* add list to pending jumps */
     else {
-        if (defs.LUA_USE_ASSERT) assert(target < fs.pc);
+        if (LUA_USE_ASSERT) assert(target < fs.pc);
         patchlistaux(fs, list, target, lopcodes.NO_REG, target);
     }
 };
@@ -305,7 +305,7 @@ const luaK_patchclose = function(fs, list, level) {
     level++;  /* argument is +1 to reserve 0 as non-op */
     for (; list !== NO_JUMP; list = getjump(fs, list)) {
         let ins = fs.f.code[list];
-        if (defs.LUA_USE_ASSERT) assert(ins.opcode === OpCodesI.OP_JMP && (ins.A === 0 || ins.A >= level));
+        if (LUA_USE_ASSERT) assert(ins.opcode === OpCodesI.OP_JMP && (ins.A === 0 || ins.A >= level));
         lopcodes.SETARG_A(ins, level);
     }
 };
@@ -328,10 +328,10 @@ const luaK_code = function(fs, i) {
 ** of parameters versus opcode.)
 */
 const luaK_codeABC = function(fs, o, a, b, c) {
-    if (defs.LUA_USE_ASSERT) assert(lopcodes.getOpMode(o) === lopcodes.iABC);
-    if (defs.LUA_USE_ASSERT) assert(lopcodes.getBMode(o) !== lopcodes.OpArgN || b === 0);
-    if (defs.LUA_USE_ASSERT) assert(lopcodes.getCMode(o) !== lopcodes.OpArgN || c === 0);
-    if (defs.LUA_USE_ASSERT) assert(a <= lopcodes.MAXARG_A && b <= lopcodes.MAXARG_B && c <= lopcodes.MAXARG_C);
+    if (LUA_USE_ASSERT) assert(lopcodes.getOpMode(o) === lopcodes.iABC);
+    if (LUA_USE_ASSERT) assert(lopcodes.getBMode(o) !== lopcodes.OpArgN || b === 0);
+    if (LUA_USE_ASSERT) assert(lopcodes.getCMode(o) !== lopcodes.OpArgN || c === 0);
+    if (LUA_USE_ASSERT) assert(a <= lopcodes.MAXARG_A && b <= lopcodes.MAXARG_B && c <= lopcodes.MAXARG_C);
     return luaK_code(fs, lopcodes.CREATE_ABC(o, a, b, c));
 };
 
@@ -339,9 +339,9 @@ const luaK_codeABC = function(fs, o, a, b, c) {
 ** Format and emit an 'iABx' instruction.
 */
 const luaK_codeABx = function(fs, o, a, bc) {
-    if (defs.LUA_USE_ASSERT) assert(lopcodes.getOpMode(o) === lopcodes.iABx || lopcodes.getOpMode(o) === lopcodes.iAsBx);
-    if (defs.LUA_USE_ASSERT) assert(lopcodes.getCMode(o) === lopcodes.OpArgN);
-    if (defs.LUA_USE_ASSERT) assert(a <= lopcodes.MAXARG_A && bc <= lopcodes.MAXARG_Bx);
+    if (LUA_USE_ASSERT) assert(lopcodes.getOpMode(o) === lopcodes.iABx || lopcodes.getOpMode(o) === lopcodes.iAsBx);
+    if (LUA_USE_ASSERT) assert(lopcodes.getCMode(o) === lopcodes.OpArgN);
+    if (LUA_USE_ASSERT) assert(a <= lopcodes.MAXARG_A && bc <= lopcodes.MAXARG_Bx);
     return luaK_code(fs, lopcodes.CREATE_ABx(o, a, bc));
 };
 
@@ -353,7 +353,7 @@ const luaK_codeAsBx = function(fs,o,A,sBx) {
 ** Emit an "extra argument" instruction (format 'iAx')
 */
 const codeextraarg = function(fs, a) {
-    if (defs.LUA_USE_ASSERT) assert(a <= lopcodes.MAXARG_Ax);
+    if (LUA_USE_ASSERT) assert(a <= lopcodes.MAXARG_Ax);
     return luaK_code(fs, lopcodes.CREATE_Ax(OpCodesI.OP_EXTRAARG, a));
 };
 
@@ -400,7 +400,7 @@ const luaK_reserveregs = function(fs, n) {
 const freereg = function(fs, reg) {
     if (!lopcodes.ISK(reg) && reg >= fs.nactvar) {
         fs.freereg--;
-        if (defs.LUA_USE_ASSERT) assert(reg === fs.freereg);
+        if (LUA_USE_ASSERT) assert(reg === fs.freereg);
     }
 };
 
@@ -520,7 +520,7 @@ const luaK_setreturns = function(fs, e, nresults) {
         lopcodes.SETARG_A(pc, fs.freereg);
         luaK_reserveregs(fs, 1);
     }
-    else if (defs.LUA_USE_ASSERT) assert(nresults === defs.LUA_MULTRET);
+    else if (LUA_USE_ASSERT) assert(nresults === defs.LUA_MULTRET);
 };
 
 const luaK_setmultret = function(fs, e) {
@@ -541,7 +541,7 @@ const luaK_setoneret = function(fs, e) {
     let ek = lparser.expkind;
     if (e.k === ek.VCALL) {  /* expression is an open function call? */
         /* already returns 1 value */
-        if (defs.LUA_USE_ASSERT) assert(getinstruction(fs, e).C === 2);
+        if (LUA_USE_ASSERT) assert(getinstruction(fs, e).C === 2);
         e.k = ek.VNONRELOC;  /* result has fixed position */
         e.u.info = getinstruction(fs, e).A;
     } else if (e.k === ek.VVARARG) {
@@ -573,7 +573,7 @@ const luaK_dischargevars = function(fs, e) {
                 freereg(fs, e.u.ind.t);
                 op = OpCodesI.OP_GETTABLE;
             } else {
-                if (defs.LUA_USE_ASSERT) assert(e.u.ind.vt === ek.VUPVAL);
+                if (LUA_USE_ASSERT) assert(e.u.ind.vt === ek.VUPVAL);
                 op = OpCodesI.OP_GETTABUP;  /* 't' is in an upvalue */
             }
             e.u.info = luaK_codeABC(fs, op, 0, e.u.ind.t, e.u.ind.idx);
@@ -632,7 +632,7 @@ const discharge2reg = function(fs, e, reg) {
             break;
         }
         default: {
-            if (defs.LUA_USE_ASSERT) assert(e.k === ek.VJMP);
+            if (LUA_USE_ASSERT) assert(e.k === ek.VJMP);
             return;  /* nothing to do... */
         }
     }
@@ -819,7 +819,7 @@ const luaK_self = function(fs, e, key) {
 */
 const negatecondition = function(fs, e) {
     let pc = getjumpcontrol(fs, e.u.info);
-    if (defs.LUA_USE_ASSERT) assert(lopcodes.testTMode(pc.opcode) && pc.opcode !== OpCodesI.OP_TESTSET && pc.opcode !== OpCodesI.OP_TEST);
+    if (LUA_USE_ASSERT) assert(lopcodes.testTMode(pc.opcode) && pc.opcode !== OpCodesI.OP_TESTSET && pc.opcode !== OpCodesI.OP_TEST);
     lopcodes.SETARG_A(pc, !(pc.A));
 };
 
@@ -936,7 +936,7 @@ const codenot = function(fs, e) {
 */
 const luaK_indexed = function(fs, t, k) {
     let ek = lparser.expkind;
-    if (defs.LUA_USE_ASSERT) assert(!hasjumps(t) && (lparser.vkisinreg(t.k) || t.k === ek.VUPVAL));
+    if (LUA_USE_ASSERT) assert(!hasjumps(t) && (lparser.vkisinreg(t.k) || t.k === ek.VUPVAL));
     t.u.ind.t = t.u.info;  /* register or upvalue index */
     t.u.ind.idx = luaK_exp2RK(fs, k);  /* R/K index for key */
     t.u.ind.vt = (t.k === ek.VUPVAL) ? ek.VUPVAL : ek.VLOCAL;
@@ -1029,7 +1029,7 @@ const codecomp = function(fs, opr, e1, e2) {
     if (e1.k === ek.VK)
         rk1 = lopcodes.RKASK(e1.u.info);
     else {
-        if (defs.LUA_USE_ASSERT) assert(e1.k === ek.VNONRELOC);
+        if (LUA_USE_ASSERT) assert(e1.k === ek.VNONRELOC);
         rk1 = e1.u.info;
     }
 
@@ -1121,14 +1121,14 @@ const luaK_posfix = function(fs, op, e1, e2, line) {
     let ek = lparser.expkind;
     switch (op) {
         case BinOpr.OPR_AND: {
-            if (defs.LUA_USE_ASSERT) assert(e1.t === NO_JUMP);  /* list closed by 'luK_infix' */
+            if (LUA_USE_ASSERT) assert(e1.t === NO_JUMP);  /* list closed by 'luK_infix' */
             luaK_dischargevars(fs, e2);
             e2.f = luaK_concat(fs, e2.f, e1.f);
             e1.to(e2);
             break;
         }
         case BinOpr.OPR_OR: {
-            if (defs.LUA_USE_ASSERT) assert(e1.f === NO_JUMP);  /* list closed by 'luK_infix' */
+            if (LUA_USE_ASSERT) assert(e1.f === NO_JUMP);  /* list closed by 'luK_infix' */
             luaK_dischargevars(fs, e2);
             e2.t = luaK_concat(fs, e2.t, e1.t);
             e1.to(e2);
@@ -1138,7 +1138,7 @@ const luaK_posfix = function(fs, op, e1, e2, line) {
             let ins = getinstruction(fs, e2);
             luaK_exp2val(fs, e2);
             if (e2.k === ek.VRELOCABLE && ins.opcode === OpCodesI.OP_CONCAT) {
-                if (defs.LUA_USE_ASSERT) assert(e1.u.info === ins.B - 1);
+                if (LUA_USE_ASSERT) assert(e1.u.info === ins.B - 1);
                 freeexp(fs, e1);
                 lopcodes.SETARG_B(ins, e1.u.info);
                 e1.k = ek.VRELOCABLE; e1.u.info = e2.u.info;
@@ -1184,7 +1184,7 @@ const luaK_fixline = function(fs, line) {
 const luaK_setlist = function(fs, base, nelems, tostore) {
     let c =  (nelems - 1)/lopcodes.LFIELDS_PER_FLUSH + 1;
     let b = (tostore === defs.LUA_MULTRET) ? 0 : tostore;
-    if (defs.LUA_USE_ASSERT) assert(tostore !== 0 && tostore <= lopcodes.LFIELDS_PER_FLUSH);
+    if (LUA_USE_ASSERT) assert(tostore !== 0 && tostore <= lopcodes.LFIELDS_PER_FLUSH);
     if (c <= lopcodes.MAXARG_C)
         luaK_codeABC(fs, OpCodesI.OP_SETLIST, base, b, c);
     else if (c <= lopcodes.MAXARG_Ax) {

--- a/src/ldblib.js
+++ b/src/ldblib.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const assert  = require('assert');
-
 const lua     = require('./lua.js');
 const lauxlib = require('./lauxlib.js');
+
+if (lua.LUA_USE_ASSERT) var assert  = require('assert');
 
 /*
 ** If L1 != L, L1 can be in any state, and therefore there are no
@@ -281,7 +281,7 @@ const hookf = function(L, ar) {
         if (ar.currentline >= 0)
             lua.lua_pushinteger(L, ar.currentline);  /* push current line */
         else lua.lua_pushnil(L);
-        assert(lua.lua_getinfo(L, ["l".charCodeAt(0), "S".charCodeAt(0)], ar));
+        if (lua.LUA_USE_ASSERT) assert(lua.lua_getinfo(L, ["l".charCodeAt(0), "S".charCodeAt(0)], ar));
         lua.lua_call(L, 2, 0);  /* call hook function */
     }
 };

--- a/src/ldblib.js
+++ b/src/ldblib.js
@@ -3,7 +3,7 @@
 const lua     = require('./lua.js');
 const lauxlib = require('./lauxlib.js');
 
-if (lua.LUA_USE_ASSERT) var assert  = require('assert');
+const assert  = require('assert');
 
 /*
 ** If L1 != L, L1 can be in any state, and therefore there are no
@@ -281,7 +281,7 @@ const hookf = function(L, ar) {
         if (ar.currentline >= 0)
             lua.lua_pushinteger(L, ar.currentline);  /* push current line */
         else lua.lua_pushnil(L);
-        if (lua.LUA_USE_ASSERT) assert(lua.lua_getinfo(L, ["l".charCodeAt(0), "S".charCodeAt(0)], ar));
+        if (LUA_USE_ASSERT) assert(lua.lua_getinfo(L, ["l".charCodeAt(0), "S".charCodeAt(0)], ar));
         lua.lua_call(L, 2, 0);  /* call hook function */
     }
 };

--- a/src/ldebug.js
+++ b/src/ldebug.js
@@ -1,9 +1,10 @@
 /*jshint esversion: 6 */
 "use strict";
 
-const assert = require('assert');
-
 const defs     = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert = require('assert');
+
 const ldo      = require('./ldo.js');
 const lfunc    = require('./lfunc.js');
 const lobject  = require('./lobject.js');
@@ -18,7 +19,7 @@ const CT = defs.constant_types;
 const TS = defs.thread_status;
 
 const currentpc = function(ci) {
-    assert(ci.callstatus & lstate.CIST_LUA);
+    if (defs.LUA_USE_ASSERT) assert(ci.callstatus & lstate.CIST_LUA);
     return ci.l_savedpc - 1;
 };
 
@@ -84,7 +85,7 @@ const lua_getstack = function(L, level, ar) {
 };
 
 const upvalname = function(p, uv) {
-    assert(uv < p.upvalues.length);
+    if (defs.LUA_USE_ASSERT) assert(uv < p.upvalues.length);
     let s = p.upvalues[uv].name;
     if (s === null) return ["?".charCodeAt(0)];
     return s.getstr();
@@ -182,12 +183,12 @@ const funcinfo = function(ar, cl) {
 const collectvalidlines = function(L, f) {
     if (f === null || f instanceof lobject.CClosure) {
         L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
-        assert(L.top <= L.ci.top, "stack overflow");
+        if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     } else {
         let lineinfo = f.l.p.lineinfo;
         let t = ltable.luaH_new(L);
         L.stack[L.top++] = new lobject.TValue(CT.LUA_TTABLE, t);
-        assert(L.top <= L.ci.top, "stack overflow");
+        if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
         let v = new lobject.TValue(CT.LUA_TBOOLEAN, true);
         for (let i = 0; i < f.l.p.length; i++)
             ltable.luaH_setint(t, lineinfo[i], v);
@@ -267,21 +268,21 @@ const lua_getinfo = function(L, what, ar) {
         ci = null;
         funcOff = L.top - 1;
         func = L.stack[funcOff];
-        assert(L, func.ttisfunction(), "function expected");
+        if (defs.LUA_USE_ASSERT) assert(L, func.ttisfunction(), "function expected");
         what = what.slice(1);  /* skip the '>' */
         L.top--;  /* pop function */
     } else {
         ci = ar.i_ci;
         func = ci.func;
         funcOff = ci.funcOff;
-        assert(ci.func.ttisfunction());
+        if (defs.LUA_USE_ASSERT) assert(ci.func.ttisfunction());
     }
 
     cl = func.ttisclosure() ? func.value : null;
     status = auxgetinfo(L, what, ar, cl, ci);
     if (what.indexOf('f'.charCodeAt(0)) >= 0) {
         L.stack[L.top++] = func;
-        assert(L.top <= L.ci.top, "stack overflow");
+        if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     }
 
     swapextra(L);

--- a/src/ldebug.js
+++ b/src/ldebug.js
@@ -3,7 +3,7 @@
 
 const defs     = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert = require('assert');
+const assert = require('assert');
 
 const ldo      = require('./ldo.js');
 const lfunc    = require('./lfunc.js');
@@ -19,7 +19,7 @@ const CT = defs.constant_types;
 const TS = defs.thread_status;
 
 const currentpc = function(ci) {
-    if (defs.LUA_USE_ASSERT) assert(ci.callstatus & lstate.CIST_LUA);
+    if (LUA_USE_ASSERT) assert(ci.callstatus & lstate.CIST_LUA);
     return ci.l_savedpc - 1;
 };
 
@@ -85,7 +85,7 @@ const lua_getstack = function(L, level, ar) {
 };
 
 const upvalname = function(p, uv) {
-    if (defs.LUA_USE_ASSERT) assert(uv < p.upvalues.length);
+    if (LUA_USE_ASSERT) assert(uv < p.upvalues.length);
     let s = p.upvalues[uv].name;
     if (s === null) return ["?".charCodeAt(0)];
     return s.getstr();
@@ -183,12 +183,12 @@ const funcinfo = function(ar, cl) {
 const collectvalidlines = function(L, f) {
     if (f === null || f instanceof lobject.CClosure) {
         L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
-        if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+        if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     } else {
         let lineinfo = f.l.p.lineinfo;
         let t = ltable.luaH_new(L);
         L.stack[L.top++] = new lobject.TValue(CT.LUA_TTABLE, t);
-        if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+        if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
         let v = new lobject.TValue(CT.LUA_TBOOLEAN, true);
         for (let i = 0; i < f.l.p.length; i++)
             ltable.luaH_setint(t, lineinfo[i], v);
@@ -268,21 +268,21 @@ const lua_getinfo = function(L, what, ar) {
         ci = null;
         funcOff = L.top - 1;
         func = L.stack[funcOff];
-        if (defs.LUA_USE_ASSERT) assert(L, func.ttisfunction(), "function expected");
+        if (LUA_USE_ASSERT) assert(L, func.ttisfunction(), "function expected");
         what = what.slice(1);  /* skip the '>' */
         L.top--;  /* pop function */
     } else {
         ci = ar.i_ci;
         func = ci.func;
         funcOff = ci.funcOff;
-        if (defs.LUA_USE_ASSERT) assert(ci.func.ttisfunction());
+        if (LUA_USE_ASSERT) assert(ci.func.ttisfunction());
     }
 
     cl = func.ttisclosure() ? func.value : null;
     status = auxgetinfo(L, what, ar, cl, ci);
     if (what.indexOf('f'.charCodeAt(0)) >= 0) {
         L.stack[L.top++] = func;
-        if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+        if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     }
 
     swapextra(L);

--- a/src/ldo.js
+++ b/src/ldo.js
@@ -3,7 +3,7 @@
 
 const defs    = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert = require('assert');
+const assert = require('assert');
 
 const lapi    = require('./lapi.js');
 const ldebug  = require('./ldebug.js');
@@ -64,8 +64,8 @@ const luaD_precall = function(L, off, nresults) {
                 luaD_hook(L, defs.LUA_HOOKCALL, -1);
             let n = f(L); /* do the actual call */
 
-            if (defs.LUA_USE_ASSERT) assert(typeof n == "number" && n >= 0 && (n|0) === n, "invalid return value from JS function (expected integer)");
-            if (defs.LUA_USE_ASSERT) assert(n < L.top - L.ci.funcOff, "not enough elements in the stack");
+            if (LUA_USE_ASSERT) assert(typeof n == "number" && n >= 0 && (n|0) === n, "invalid return value from JS function (expected integer)");
+            if (LUA_USE_ASSERT) assert(n < L.top - L.ci.funcOff, "not enough elements in the stack");
 
             luaD_poscall(L, ci, L.top - n, n);
 
@@ -173,7 +173,7 @@ const luaD_hook = function(L, event, line) {
         L.allowhook = 0;  /* cannot call hooks inside a hook */
         ci.callstatus |= lstate.CIST_HOOKED;
         hook(L, ar);
-        if (defs.LUA_USE_ASSERT) assert(!L.allowhook);
+        if (LUA_USE_ASSERT) assert(!L.allowhook);
         L.allowhook = 1;
         ci.top = ci_top;
         L.top = top;
@@ -322,9 +322,9 @@ const finishCcall = function(L, status) {
     let ci = L.ci;
 
     /* must have a continuation and must be able to call it */
-    if (defs.LUA_USE_ASSERT) assert(ci.c_k !== null && L.nny === 0);
+    if (LUA_USE_ASSERT) assert(ci.c_k !== null && L.nny === 0);
     /* error status can only happen in a protected call */
-    if (defs.LUA_USE_ASSERT) assert(ci.callstatus & lstate.CIST_YPCALL || status === TS.LUA_YIELD);
+    if (LUA_USE_ASSERT) assert(ci.callstatus & lstate.CIST_YPCALL || status === TS.LUA_YIELD);
 
     if (ci.callstatus & TS.CIST_YPCALL) {  /* was inside a pcall? */
         ci.callstatus &= ~TS.CIST_YPCALL;  /* continuation is also inside it */
@@ -335,7 +335,7 @@ const finishCcall = function(L, status) {
        handled */
     if (ci.nresults === defs.LUA_MULTRET && L.ci.top < L.top) L.ci.top = L.top;
     let n = ci.c_k(L, status, ci.c_ctx);  /* call continuation function */
-    if (defs.LUA_USE_ASSERT) assert(n < (L.top - L.ci.funcOff), "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(n < (L.top - L.ci.funcOff), "not enough elements in the stack");
     luaD_poscall(L, ci, L.top - n, n);  /* finish 'luaD_precall' */
 };
 
@@ -401,7 +401,7 @@ const recover = function(L, status) {
 const resume_error = function(L, msg, narg) {
     L.top -= narg;  /* remove args from the stack */
     L.stack[L.top++] = new lobject.TValue(CT.LUA_TLNGSTR, lstring.luaS_newliteral(L, msg));  /* push error message */
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     return TS.LUA_ERRRUN;
 };
 
@@ -419,7 +419,7 @@ const resume = function(L, n) {
         if (!luaD_precall(L, firstArg - 1, defs.LUA_MULTRET))  /* Lua function? */
             lvm.luaV_execute(L);  /* call it */
     } else {  /* resuming from previous yield */
-        if (defs.LUA_USE_ASSERT) assert(L.status === TS.LUA_YIELD);
+        if (LUA_USE_ASSERT) assert(L.status === TS.LUA_YIELD);
         L.status = TS.LUA_OK;  /* mark that it is running (again) */
         ci.funcOff = ci.extra;
         ci.func = L.stack[ci.funcOff];
@@ -429,7 +429,7 @@ const resume = function(L, n) {
         else {  /* 'common' yield */
             if (ci.c_k !== null) {  /* does it have a continuation function? */
                 n = ci.c_k(L, TS.LUA_YIELD, ci.c_ctx); /* call continuation */
-                if (defs.LUA_USE_ASSERT) assert(n < (L.top - L.ci.funcOff), "not enough elements in the stack");
+                if (LUA_USE_ASSERT) assert(n < (L.top - L.ci.funcOff), "not enough elements in the stack");
                 firstArg = L.top - n;  /* yield results come from continuation */
             }
 
@@ -455,7 +455,7 @@ const lua_resume = function(L, from, nargs) {
 
     L.nny = 0;  /* allow yields */
 
-    if (defs.LUA_USE_ASSERT) assert((L.status === TS.LUA_OK ? nargs + 1: nargs) < (L.top - L.ci.funcOff),
+    if (LUA_USE_ASSERT) assert((L.status === TS.LUA_OK ? nargs + 1: nargs) < (L.top - L.ci.funcOff),
         "not enough elements in the stack");
 
     let status = luaD_rawrunprotected(L, resume, nargs);
@@ -472,12 +472,12 @@ const lua_resume = function(L, from, nargs) {
             seterrorobj(L, status, L.top);  /* push error message */
             L.ci.top = L.top;
         } else
-            if (defs.LUA_USE_ASSERT) assert(status === L.status);  /* normal end or yield */
+            if (LUA_USE_ASSERT) assert(status === L.status);  /* normal end or yield */
     }
 
     L.nny = oldnny;  /* restore 'nny' */
     L.nCcalls--;
-    if (defs.LUA_USE_ASSERT) assert(L.nCcalls === (from ? from.nCcalls : 0));
+    if (LUA_USE_ASSERT) assert(L.nCcalls === (from ? from.nCcalls : 0));
     return status;
 };
 
@@ -487,7 +487,7 @@ const lua_isyieldable = function(L) {
 
 const lua_yieldk = function(L, nresults, ctx, k) {
     let ci = L.ci;
-    if (defs.LUA_USE_ASSERT) assert(nresults < (L.top - L.ci.funcOff), "not enough elements in the stack");
+    if (LUA_USE_ASSERT) assert(nresults < (L.top - L.ci.funcOff), "not enough elements in the stack");
 
     if (L.nny > 0) {
         if (L !== L.l_G.mainthread)
@@ -499,7 +499,7 @@ const lua_yieldk = function(L, nresults, ctx, k) {
     L.status = TS.LUA_YIELD;
     ci.extra = ci.funcOff;  /* save current 'func' */
     if (ci.callstatus & lstate.CIST_LUA)  {  /* inside a hook? */
-        if (defs.LUA_USE_ASSERT) assert(k === null, "hooks cannot continue after yielding");
+        if (LUA_USE_ASSERT) assert(k === null, "hooks cannot continue after yielding");
     } else {
         ci.c_k = k;
         if (k !== null)  /* is there a continuation? */
@@ -509,7 +509,7 @@ const lua_yieldk = function(L, nresults, ctx, k) {
         luaD_throw(L, TS.LUA_YIELD);
     }
 
-    if (defs.LUA_USE_ASSERT) assert(ci.callstatus & lstate.CIST_HOOKED);  /* must be inside a hook */
+    if (LUA_USE_ASSERT) assert(ci.callstatus & lstate.CIST_HOOKED);  /* must be inside a hook */
     return 0;  /* return to 'luaD_hook' */
 };
 
@@ -579,7 +579,7 @@ const f_parser = function(L, p) {
         cl = lparser.luaY_parser(L, p.z, p.buff, p.dyd, p.name, c);
     }
 
-    if (defs.LUA_USE_ASSERT) assert(cl.nupvalues === cl.p.upvalues.length);
+    if (LUA_USE_ASSERT) assert(cl.nupvalues === cl.p.upvalues.length);
     lfunc.luaF_initupvals(L, cl);
 };
 

--- a/src/ldo.js
+++ b/src/ldo.js
@@ -1,9 +1,10 @@
 /*jshint esversion: 6 */
 "use strict";
 
-const assert = require('assert');
-
 const defs    = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert = require('assert');
+
 const lapi    = require('./lapi.js');
 const ldebug  = require('./ldebug.js');
 const lfunc   = require('./lfunc.js');
@@ -63,8 +64,8 @@ const luaD_precall = function(L, off, nresults) {
                 luaD_hook(L, defs.LUA_HOOKCALL, -1);
             let n = f(L); /* do the actual call */
 
-            assert(typeof n == "number" && n >= 0 && (n|0) === n, "invalid return value from JS function (expected integer)");
-            assert(n < L.top - L.ci.funcOff, "not enough elements in the stack");
+            if (defs.LUA_USE_ASSERT) assert(typeof n == "number" && n >= 0 && (n|0) === n, "invalid return value from JS function (expected integer)");
+            if (defs.LUA_USE_ASSERT) assert(n < L.top - L.ci.funcOff, "not enough elements in the stack");
 
             luaD_poscall(L, ci, L.top - n, n);
 
@@ -172,7 +173,7 @@ const luaD_hook = function(L, event, line) {
         L.allowhook = 0;  /* cannot call hooks inside a hook */
         ci.callstatus |= lstate.CIST_HOOKED;
         hook(L, ar);
-        assert(!L.allowhook);
+        if (defs.LUA_USE_ASSERT) assert(!L.allowhook);
         L.allowhook = 1;
         ci.top = ci_top;
         L.top = top;
@@ -321,9 +322,9 @@ const finishCcall = function(L, status) {
     let ci = L.ci;
 
     /* must have a continuation and must be able to call it */
-    assert(ci.c_k !== null && L.nny === 0);
+    if (defs.LUA_USE_ASSERT) assert(ci.c_k !== null && L.nny === 0);
     /* error status can only happen in a protected call */
-    assert(ci.callstatus & lstate.CIST_YPCALL || status === TS.LUA_YIELD);
+    if (defs.LUA_USE_ASSERT) assert(ci.callstatus & lstate.CIST_YPCALL || status === TS.LUA_YIELD);
 
     if (ci.callstatus & TS.CIST_YPCALL) {  /* was inside a pcall? */
         ci.callstatus &= ~TS.CIST_YPCALL;  /* continuation is also inside it */
@@ -334,7 +335,7 @@ const finishCcall = function(L, status) {
        handled */
     if (ci.nresults === defs.LUA_MULTRET && L.ci.top < L.top) L.ci.top = L.top;
     let n = ci.c_k(L, status, ci.c_ctx);  /* call continuation function */
-    assert(n < (L.top - L.ci.funcOff), "not enough elements in the stack");
+    if (defs.LUA_USE_ASSERT) assert(n < (L.top - L.ci.funcOff), "not enough elements in the stack");
     luaD_poscall(L, ci, L.top - n, n);  /* finish 'luaD_precall' */
 };
 
@@ -400,7 +401,7 @@ const recover = function(L, status) {
 const resume_error = function(L, msg, narg) {
     L.top -= narg;  /* remove args from the stack */
     L.stack[L.top++] = new lobject.TValue(CT.LUA_TLNGSTR, lstring.luaS_newliteral(L, msg));  /* push error message */
-    assert(L.top <= L.ci.top, "stack overflow");
+    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     return TS.LUA_ERRRUN;
 };
 
@@ -418,7 +419,7 @@ const resume = function(L, n) {
         if (!luaD_precall(L, firstArg - 1, defs.LUA_MULTRET))  /* Lua function? */
             lvm.luaV_execute(L);  /* call it */
     } else {  /* resuming from previous yield */
-        assert(L.status === TS.LUA_YIELD);
+        if (defs.LUA_USE_ASSERT) assert(L.status === TS.LUA_YIELD);
         L.status = TS.LUA_OK;  /* mark that it is running (again) */
         ci.funcOff = ci.extra;
         ci.func = L.stack[ci.funcOff];
@@ -428,7 +429,7 @@ const resume = function(L, n) {
         else {  /* 'common' yield */
             if (ci.c_k !== null) {  /* does it have a continuation function? */
                 n = ci.c_k(L, TS.LUA_YIELD, ci.c_ctx); /* call continuation */
-                assert(n < (L.top - L.ci.funcOff), "not enough elements in the stack");
+                if (defs.LUA_USE_ASSERT) assert(n < (L.top - L.ci.funcOff), "not enough elements in the stack");
                 firstArg = L.top - n;  /* yield results come from continuation */
             }
 
@@ -454,7 +455,7 @@ const lua_resume = function(L, from, nargs) {
 
     L.nny = 0;  /* allow yields */
 
-    assert((L.status === TS.LUA_OK ? nargs + 1: nargs) < (L.top - L.ci.funcOff),
+    if (defs.LUA_USE_ASSERT) assert((L.status === TS.LUA_OK ? nargs + 1: nargs) < (L.top - L.ci.funcOff),
         "not enough elements in the stack");
 
     let status = luaD_rawrunprotected(L, resume, nargs);
@@ -471,12 +472,12 @@ const lua_resume = function(L, from, nargs) {
             seterrorobj(L, status, L.top);  /* push error message */
             L.ci.top = L.top;
         } else
-            assert(status === L.status);  /* normal end or yield */
+            if (defs.LUA_USE_ASSERT) assert(status === L.status);  /* normal end or yield */
     }
 
     L.nny = oldnny;  /* restore 'nny' */
     L.nCcalls--;
-    assert(L.nCcalls === (from ? from.nCcalls : 0));
+    if (defs.LUA_USE_ASSERT) assert(L.nCcalls === (from ? from.nCcalls : 0));
     return status;
 };
 
@@ -486,7 +487,7 @@ const lua_isyieldable = function(L) {
 
 const lua_yieldk = function(L, nresults, ctx, k) {
     let ci = L.ci;
-    assert(nresults < (L.top - L.ci.funcOff), "not enough elements in the stack");
+    if (defs.LUA_USE_ASSERT) assert(nresults < (L.top - L.ci.funcOff), "not enough elements in the stack");
 
     if (L.nny > 0) {
         if (L !== L.l_G.mainthread)
@@ -497,9 +498,9 @@ const lua_yieldk = function(L, nresults, ctx, k) {
 
     L.status = TS.LUA_YIELD;
     ci.extra = ci.funcOff;  /* save current 'func' */
-    if (ci.callstatus & lstate.CIST_LUA)  /* inside a hook? */
-        assert(k === null, "hooks cannot continue after yielding");
-    else {
+    if (ci.callstatus & lstate.CIST_LUA)  {  /* inside a hook? */
+        if (defs.LUA_USE_ASSERT) assert(k === null, "hooks cannot continue after yielding");
+    } else {
         ci.c_k = k;
         if (k !== null)  /* is there a continuation? */
             ci.c_ctx = ctx;  /* save context */
@@ -508,7 +509,7 @@ const lua_yieldk = function(L, nresults, ctx, k) {
         luaD_throw(L, TS.LUA_YIELD);
     }
 
-    assert(ci.callstatus & lstate.CIST_HOOKED);  /* must be inside a hook */
+    if (defs.LUA_USE_ASSERT) assert(ci.callstatus & lstate.CIST_HOOKED);  /* must be inside a hook */
     return 0;  /* return to 'luaD_hook' */
 };
 
@@ -578,7 +579,7 @@ const f_parser = function(L, p) {
         cl = lparser.luaY_parser(L, p.z, p.buff, p.dyd, p.name, c);
     }
 
-    assert(cl.nupvalues === cl.p.upvalues.length);
+    if (defs.LUA_USE_ASSERT) assert(cl.nupvalues === cl.p.upvalues.length);
     lfunc.luaF_initupvals(L, cl);
 };
 

--- a/src/lfunc.js
+++ b/src/lfunc.js
@@ -3,7 +3,7 @@
 
 const defs    = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert  = require('assert');
+const assert  = require('assert');
 
 const lobject = require('./lobject.js');
 const CT      = defs.constant_types;
@@ -59,7 +59,7 @@ const luaF_findupval = function(L, level) {
     let prevp;
     let p = L.openupval;
     while (p !== null && p.v >= level) {
-        if (defs.LUA_USE_ASSERT) assert(p.isopen());
+        if (LUA_USE_ASSERT) assert(p.isopen());
         if (p.v === level) /* found a corresponding upvalue? */
             return p; /* return it */
         prevp = p;
@@ -82,7 +82,7 @@ const luaF_findupval = function(L, level) {
 const luaF_close = function(L, level) {
     while (L.openupval !== null && L.openupval.v >= level) {
         let uv = L.openupval;
-        if (defs.LUA_USE_ASSERT) assert(uv.isopen());
+        if (LUA_USE_ASSERT) assert(uv.isopen());
         L.openupval = uv.open_next; /* remove from 'open' list */
         if (uv.refcount > 0) {
             let from = uv.L.stack[uv.v];

--- a/src/lfunc.js
+++ b/src/lfunc.js
@@ -1,8 +1,10 @@
 /*jshint esversion: 6 */
 "use strict";
-const assert  = require('assert');
 
 const defs    = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert  = require('assert');
+
 const lobject = require('./lobject.js');
 const CT      = defs.constant_types;
 
@@ -57,7 +59,7 @@ const luaF_findupval = function(L, level) {
     let prevp;
     let p = L.openupval;
     while (p !== null && p.v >= level) {
-        assert(p.isopen());
+        if (defs.LUA_USE_ASSERT) assert(p.isopen());
         if (p.v === level) /* found a corresponding upvalue? */
             return p; /* return it */
         prevp = p;
@@ -80,7 +82,7 @@ const luaF_findupval = function(L, level) {
 const luaF_close = function(L, level) {
     while (L.openupval !== null && L.openupval.v >= level) {
         let uv = L.openupval;
-        assert(uv.isopen());
+        if (defs.LUA_USE_ASSERT) assert(uv.isopen());
         L.openupval = uv.open_next; /* remove from 'open' list */
         if (uv.refcount > 0) {
             let from = uv.L.stack[uv.v];

--- a/src/liolib.js
+++ b/src/liolib.js
@@ -1,10 +1,11 @@
 "use strict";
 
-const assert  = require('assert');
 const fs      = require('fs');
 
 const lua     = require('./lua.js');
 const lauxlib = require('./lauxlib.js');
+
+if (lua.LUA_USE_ASSERT) var assert  = require('assert');
 
 const IO_PREFIX = "_IO_";
 const IOPREF_LEN = IO_PREFIX.length;
@@ -44,7 +45,7 @@ const tofile = function(L) {
     let p = tolstream(L);
     if (isclosed(p))
         lauxlib.luaL_error(L, lua.to_luastring("attempt to use a closed file"));
-    assert(p.f);
+    if (lua.LUA_USE_ASSERT) assert(p.f);
     return p.f;
 };
 

--- a/src/liolib.js
+++ b/src/liolib.js
@@ -5,7 +5,7 @@ const fs      = require('fs');
 const lua     = require('./lua.js');
 const lauxlib = require('./lauxlib.js');
 
-if (lua.LUA_USE_ASSERT) var assert  = require('assert');
+const assert  = require('assert');
 
 const IO_PREFIX = "_IO_";
 const IOPREF_LEN = IO_PREFIX.length;
@@ -45,7 +45,7 @@ const tofile = function(L) {
     let p = tolstream(L);
     if (isclosed(p))
         lauxlib.luaL_error(L, lua.to_luastring("attempt to use a closed file"));
-    if (lua.LUA_USE_ASSERT) assert(p.f);
+    if (LUA_USE_ASSERT) assert(p.f);
     return p.f;
 };
 

--- a/src/llex.js
+++ b/src/llex.js
@@ -1,8 +1,9 @@
 "use strict";
 
-const assert   = require('assert');
-
 const defs     = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert   = require('assert');
+
 const ldebug   = require('./ldebug.js');
 const ldo      = require('./ldo.js');
 const ljstype  = require('./ljstype.js');
@@ -153,7 +154,7 @@ const luaX_newstring = function(ls, str) {
     } else { /* string already present */
         /* HACK: Workaround lack of ltable 'keyfromval' */
         let tpair = ls.h.strong.get(lstring.luaS_hashlongstr(ts));
-        assert(tpair.value == o);
+        if (defs.LUA_USE_ASSERT) assert(tpair.value == o);
         ts = tpair.key.tsvalue(); /* re-use value previously stored */
     }
     return ts;
@@ -165,7 +166,7 @@ const luaX_newstring = function(ls, str) {
 */
 const inclinenumber = function(ls) {
     let old = ls.current;
-    assert(currIsNewline(ls));
+    if (defs.LUA_USE_ASSERT) assert(currIsNewline(ls));
     next(ls);  /* skip '\n' or '\r' */
     if (currIsNewline(ls) && ls.current !== old)
         next(ls);  /* skip '\n\r' or '\r\n' */
@@ -225,7 +226,7 @@ const check_next2 = function(ls, set) {
 const read_numeral = function(ls, seminfo) {
     let expo = "Ee";
     let first = ls.current;
-    assert(ljstype.lisdigit(ls.current));
+    if (defs.LUA_USE_ASSERT) assert(ljstype.lisdigit(ls.current));
     save_and_next(ls);
     if (first === char['0'] && check_next2(ls, "xX"))  /* hexadecimal? */
         expo = "Pp";
@@ -249,7 +250,7 @@ const read_numeral = function(ls, seminfo) {
         seminfo.i = obj.value;
         return R.TK_INT;
     } else {
-        assert(obj.ttisfloat());
+        if (defs.LUA_USE_ASSERT) assert(obj.ttisfloat());
         seminfo.r = obj.value;
         return R.TK_FLT;
     }
@@ -285,7 +286,7 @@ const luaX_syntaxerror = function(ls, msg) {
 const skip_sep = function(ls) {
     let count = 0;
     let s = ls.current;
-    assert(s === char['['] || s === char[']']);
+    if (defs.LUA_USE_ASSERT) assert(s === char['['] || s === char[']']);
     save_and_next(ls);
     while (ls.current === char['=']) {
         save_and_next(ls);
@@ -471,7 +472,7 @@ const llex = function(ls, seminfo) {
     ls.buff.buffer = [];
 
     for (;;) {
-        assert(typeof ls.current == "number");
+        if (defs.LUA_USE_ASSERT) assert(typeof ls.current == "number");
         switch (ls.current) {
             case char['\n']: case char['\r']: {  /* line breaks */
                 inclinenumber(ls);
@@ -601,7 +602,7 @@ const luaX_next = function(ls) {
 };
 
 const luaX_lookahead = function(ls) {
-    assert(ls.lookahead.token === R.TK_EOS);
+    if (defs.LUA_USE_ASSERT) assert(ls.lookahead.token === R.TK_EOS);
     ls.lookahead.token = llex(ls, ls.lookahead.seminfo);
     return ls.lookahead.token;
 };

--- a/src/llex.js
+++ b/src/llex.js
@@ -2,7 +2,7 @@
 
 const defs     = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert   = require('assert');
+const assert   = require('assert');
 
 const ldebug   = require('./ldebug.js');
 const ldo      = require('./ldo.js');
@@ -154,7 +154,7 @@ const luaX_newstring = function(ls, str) {
     } else { /* string already present */
         /* HACK: Workaround lack of ltable 'keyfromval' */
         let tpair = ls.h.strong.get(lstring.luaS_hashlongstr(ts));
-        if (defs.LUA_USE_ASSERT) assert(tpair.value == o);
+        if (LUA_USE_ASSERT) assert(tpair.value == o);
         ts = tpair.key.tsvalue(); /* re-use value previously stored */
     }
     return ts;
@@ -166,7 +166,7 @@ const luaX_newstring = function(ls, str) {
 */
 const inclinenumber = function(ls) {
     let old = ls.current;
-    if (defs.LUA_USE_ASSERT) assert(currIsNewline(ls));
+    if (LUA_USE_ASSERT) assert(currIsNewline(ls));
     next(ls);  /* skip '\n' or '\r' */
     if (currIsNewline(ls) && ls.current !== old)
         next(ls);  /* skip '\n\r' or '\r\n' */
@@ -226,7 +226,7 @@ const check_next2 = function(ls, set) {
 const read_numeral = function(ls, seminfo) {
     let expo = "Ee";
     let first = ls.current;
-    if (defs.LUA_USE_ASSERT) assert(ljstype.lisdigit(ls.current));
+    if (LUA_USE_ASSERT) assert(ljstype.lisdigit(ls.current));
     save_and_next(ls);
     if (first === char['0'] && check_next2(ls, "xX"))  /* hexadecimal? */
         expo = "Pp";
@@ -250,7 +250,7 @@ const read_numeral = function(ls, seminfo) {
         seminfo.i = obj.value;
         return R.TK_INT;
     } else {
-        if (defs.LUA_USE_ASSERT) assert(obj.ttisfloat());
+        if (LUA_USE_ASSERT) assert(obj.ttisfloat());
         seminfo.r = obj.value;
         return R.TK_FLT;
     }
@@ -286,7 +286,7 @@ const luaX_syntaxerror = function(ls, msg) {
 const skip_sep = function(ls) {
     let count = 0;
     let s = ls.current;
-    if (defs.LUA_USE_ASSERT) assert(s === char['['] || s === char[']']);
+    if (LUA_USE_ASSERT) assert(s === char['['] || s === char[']']);
     save_and_next(ls);
     while (ls.current === char['=']) {
         save_and_next(ls);
@@ -472,7 +472,7 @@ const llex = function(ls, seminfo) {
     ls.buff.buffer = [];
 
     for (;;) {
-        if (defs.LUA_USE_ASSERT) assert(typeof ls.current == "number");
+        if (LUA_USE_ASSERT) assert(typeof ls.current == "number");
         switch (ls.current) {
             case char['\n']: case char['\r']: {  /* line breaks */
                 inclinenumber(ls);
@@ -602,7 +602,7 @@ const luaX_next = function(ls) {
 };
 
 const luaX_lookahead = function(ls) {
-    if (defs.LUA_USE_ASSERT) assert(ls.lookahead.token === R.TK_EOS);
+    if (LUA_USE_ASSERT) assert(ls.lookahead.token === R.TK_EOS);
     ls.lookahead.token = llex(ls, ls.lookahead.seminfo);
     return ls.lookahead.token;
 };

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -3,7 +3,7 @@
 
 const defs    = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert = require('assert');
+const assert = require('assert');
 
 const ljstype = require('./ljstype.js');
 const ldebug  = require('./ldebug.js');
@@ -165,7 +165,7 @@ class TValue {
     }
 
     tsvalue() {
-        if (defs.LUA_USE_ASSERT) assert(this.ttisstring());
+        if (LUA_USE_ASSERT) assert(this.ttisstring());
         return this.value;
     }
 
@@ -275,7 +275,7 @@ const UTF8BUFFSZ = 8;
 
 const luaO_utf8desc = function(buff, x) {
     let n = 1;  /* number of bytes put in buffer (backwards) */
-    if (defs.LUA_USE_ASSERT) assert(x <= 0x10FFFF);
+    if (LUA_USE_ASSERT) assert(x <= 0x10FFFF);
     if (x < 0x80)  /* ascii? */
         buff[UTF8BUFFSZ - 1] = x;
     else {  /* need continuation bytes */
@@ -426,7 +426,7 @@ const luaO_str2num = function(s) {
 const luaO_utf8esc = function(x) {
     let buff = [];
     let n = 1;  /* number of bytes put in buffer (backwards) */
-    if (defs.LUA_USE_ASSERT) assert(x <= 0x10ffff);
+    if (LUA_USE_ASSERT) assert(x <= 0x10ffff);
     if (x < 0x80)  /* ascii? */
         buff[UTF8BUFFSZ - 1] = x;
     else {  /* need continuation bytes */
@@ -590,7 +590,7 @@ const luaO_arith = function(L, op, p1, p2, res) {
         }
     }
     /* could not perform raw operation; try metamethod */
-    if (defs.LUA_USE_ASSERT) assert(L !== null);  /* should not fail when folding (compile time) */
+    if (LUA_USE_ASSERT) assert(L !== null);  /* should not fail when folding (compile time) */
     ltm.luaT_trybinTM(L, p1, p2, res, (op - defs.LUA_OPADD) + ltm.TMS.TM_ADD);
 };
 

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -1,9 +1,10 @@
  /*jshint esversion: 6 */
 "use strict";
 
-const assert = require('assert');
-
 const defs    = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert = require('assert');
+
 const ljstype = require('./ljstype.js');
 const ldebug  = require('./ldebug.js');
 const lstring = require('./lstring.js');
@@ -164,7 +165,7 @@ class TValue {
     }
 
     tsvalue() {
-        assert(this.ttisstring());
+        if (defs.LUA_USE_ASSERT) assert(this.ttisstring());
         return this.value;
     }
 
@@ -274,7 +275,7 @@ const UTF8BUFFSZ = 8;
 
 const luaO_utf8desc = function(buff, x) {
     let n = 1;  /* number of bytes put in buffer (backwards) */
-    assert(x <= 0x10FFFF);
+    if (defs.LUA_USE_ASSERT) assert(x <= 0x10FFFF);
     if (x < 0x80)  /* ascii? */
         buff[UTF8BUFFSZ - 1] = x;
     else {  /* need continuation bytes */
@@ -425,7 +426,7 @@ const luaO_str2num = function(s) {
 const luaO_utf8esc = function(x) {
     let buff = [];
     let n = 1;  /* number of bytes put in buffer (backwards) */
-    assert(x <= 0x10ffff);
+    if (defs.LUA_USE_ASSERT) assert(x <= 0x10ffff);
     if (x < 0x80)  /* ascii? */
         buff[UTF8BUFFSZ - 1] = x;
     else {  /* need continuation bytes */
@@ -589,7 +590,7 @@ const luaO_arith = function(L, op, p1, p2, res) {
         }
     }
     /* could not perform raw operation; try metamethod */
-    assert(L !== null);  /* should not fail when folding (compile time) */
+    if (defs.LUA_USE_ASSERT) assert(L !== null);  /* should not fail when folding (compile time) */
     ltm.luaT_trybinTM(L, p1, p2, res, (op - defs.LUA_OPADD) + ltm.TMS.TM_ADD);
 };
 

--- a/src/lparser.js
+++ b/src/lparser.js
@@ -3,7 +3,7 @@
 
 const defs     = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert = require('assert');
+const assert = require('assert');
 
 const lcode    = require('./lcode.js');
 const lfunc    = require('./lfunc.js');
@@ -262,7 +262,7 @@ const new_localvarliteral = function(ls, name) {
 
 const getlocvar = function(fs, i) {
     let idx = fs.ls.dyd.actvar.arr[fs.firstlocal + i].idx;
-    if (defs.LUA_USE_ASSERT) assert(idx < fs.nlocvars);
+    if (LUA_USE_ASSERT) assert(idx < fs.nlocvars);
     return fs.f.locvars[idx];
 };
 
@@ -353,7 +353,7 @@ const singlevar = function(ls, vr) {
     if (vr.k === expkind.VVOID) {  /* global name? */
         let key = new expdesc();
         singlevaraux(fs, ls.envn, vr, 1);  /* get environment variable */
-        if (defs.LUA_USE_ASSERT) assert(vr.k !== expkind.VVOID);  /* this one must exist */
+        if (LUA_USE_ASSERT) assert(vr.k !== expkind.VVOID);  /* this one must exist */
         codestring(ls, key, varname);  /* key is variable name */
         lcode.luaK_indexed(fs, vr, key);  /* env[varname] */
     }
@@ -393,7 +393,7 @@ const closegoto = function(ls, g, label) {
     let fs = ls.fs;
     let gl = ls.dyd.gt;
     let gt = gl.arr[g];
-    if (defs.LUA_USE_ASSERT) assert(eqstr(gt.name, label.name));
+    if (LUA_USE_ASSERT) assert(eqstr(gt.name, label.name));
     if (gt.nactvar < label.nactvar) {
         let vname = getlocvar(fs, gt.nactvar).varname;
         let msg = lobject.luaO_pushfstring(ls.L, defs.to_luastring("<goto %s> at line %d jumps into the scope of local '%s'"),
@@ -484,7 +484,7 @@ const enterblock = function(fs, bl, isloop) {
     bl.upval = 0;
     bl.previous = fs.bl;
     fs.bl = bl;
-    if (defs.LUA_USE_ASSERT) assert(fs.freereg === fs.nactvar);
+    if (LUA_USE_ASSERT) assert(fs.freereg === fs.nactvar);
 };
 
 /*
@@ -566,7 +566,7 @@ const leaveblock = function(fs) {
 
     fs.bl = bl.previous;
     removevars(fs, bl.nactvar);
-    if (defs.LUA_USE_ASSERT) assert(bl.nactvar === fs.nactvar);
+    if (LUA_USE_ASSERT) assert(bl.nactvar === fs.nactvar);
     fs.freereg = fs.nactvar;  /* free registers */
     ls.dyd.label.n = bl.firstlabel;  /* remove local labels */
     if (bl.previous)  /* inner block? */
@@ -729,7 +729,7 @@ const constructor = function(ls, t) {
     lcode.luaK_exp2nextreg(ls.fs, t);  /* fix it at stack top */
     checknext(ls, char['{']);
     do {
-        if (defs.LUA_USE_ASSERT) assert(cc.v.k === expkind.VVOID || cc.tostore > 0);
+        if (LUA_USE_ASSERT) assert(cc.v.k === expkind.VVOID || cc.tostore > 0);
         if (ls.t.token === char['}']) break;
         closelistfield(fs, cc);
         field(ls, cc);
@@ -831,7 +831,7 @@ const funcargs = function(ls, f, line) {
             llex.luaX_syntaxerror(ls, defs.to_luastring("function arguments expected", true));
         }
     }
-    if (defs.LUA_USE_ASSERT) assert(f.k === expkind.VNONRELOC);
+    if (LUA_USE_ASSERT) assert(f.k === expkind.VNONRELOC);
     let nparams;
     let base = f.u.info;  /* base register for call */
     if (hasmultret(args.k))
@@ -1231,7 +1231,7 @@ const exp1 = function(ls) {
     let e = new expdesc();
     expr(ls, e);
     lcode.luaK_exp2nextreg(ls.fs, e);
-    if (defs.LUA_USE_ASSERT) assert(e.k === expkind.VNONRELOC);
+    if (LUA_USE_ASSERT) assert(e.k === expkind.VNONRELOC);
     let reg = e.u.info;
     return reg;
 };
@@ -1451,7 +1451,7 @@ const retstat = function(ls) {
             lcode.luaK_setmultret(fs, e);
             if (e.k === expkind.VCALL && nret === 1) {  /* tail call? */
                 lopcodes.SET_OPCODE(lcode.getinstruction(fs, e), OpCodesI.OP_TAILCALL);
-                if (defs.LUA_USE_ASSERT) assert(lcode.getinstruction(fs, e).A === fs.nactvar);
+                if (LUA_USE_ASSERT) assert(lcode.getinstruction(fs, e).A === fs.nactvar);
             }
             first = fs.nactvar;
             nret = defs.LUA_MULTRET;  /* return all values */
@@ -1461,7 +1461,7 @@ const retstat = function(ls) {
             else {
                 lcode.luaK_exp2nextreg(fs, e);  /* values must go to the stack */
                 first = fs.nactvar;  /* return all active values */
-                if (defs.LUA_USE_ASSERT) assert(nret === fs.freereg - first);
+                if (LUA_USE_ASSERT) assert(nret === fs.freereg - first);
             }
         }
     }
@@ -1532,7 +1532,7 @@ const statement = function(ls) {
         }
     }
 
-    if (defs.LUA_USE_ASSERT) assert(ls.fs.f.maxstacksize >= ls.fs.freereg && ls.fs.freereg >= ls.fs.nactvar);
+    if (LUA_USE_ASSERT) assert(ls.fs.f.maxstacksize >= ls.fs.freereg && ls.fs.freereg >= ls.fs.nactvar);
     ls.fs.freereg = ls.fs.nactvar;  /* free registers */
     leavelevel(ls);
 };
@@ -1568,9 +1568,9 @@ const luaY_parser = function(L, z, buff, dyd, name, firstchar) {
     dyd.actvar.n = dyd.gt.n = dyd.label.n = 0;
     llex.luaX_setinput(L, lexstate, z, funcstate.f.source, firstchar);
     mainfunc(lexstate, funcstate);
-    if (defs.LUA_USE_ASSERT) assert(!funcstate.prev && funcstate.nups === 1 && !lexstate.fs);
+    if (LUA_USE_ASSERT) assert(!funcstate.prev && funcstate.nups === 1 && !lexstate.fs);
     /* all scopes should be correctly finished */
-    if (defs.LUA_USE_ASSERT) assert(dyd.actvar.n === 0 && dyd.gt.n === 0 && dyd.label.n === 0);
+    if (LUA_USE_ASSERT) assert(dyd.actvar.n === 0 && dyd.gt.n === 0 && dyd.label.n === 0);
     L.top--;  /* remove scanner's table */
     return cl;  /* closure is on the stack, too */
 };

--- a/src/lparser.js
+++ b/src/lparser.js
@@ -1,8 +1,10 @@
 "use strict";
 
-const assert = require('assert');
 
 const defs     = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert = require('assert');
+
 const lcode    = require('./lcode.js');
 const lfunc    = require('./lfunc.js');
 const llex     = require('./llex.js');
@@ -260,7 +262,7 @@ const new_localvarliteral = function(ls, name) {
 
 const getlocvar = function(fs, i) {
     let idx = fs.ls.dyd.actvar.arr[fs.firstlocal + i].idx;
-    assert(idx < fs.nlocvars);
+    if (defs.LUA_USE_ASSERT) assert(idx < fs.nlocvars);
     return fs.f.locvars[idx];
 };
 
@@ -351,7 +353,7 @@ const singlevar = function(ls, vr) {
     if (vr.k === expkind.VVOID) {  /* global name? */
         let key = new expdesc();
         singlevaraux(fs, ls.envn, vr, 1);  /* get environment variable */
-        assert(vr.k !== expkind.VVOID);  /* this one must exist */
+        if (defs.LUA_USE_ASSERT) assert(vr.k !== expkind.VVOID);  /* this one must exist */
         codestring(ls, key, varname);  /* key is variable name */
         lcode.luaK_indexed(fs, vr, key);  /* env[varname] */
     }
@@ -391,7 +393,7 @@ const closegoto = function(ls, g, label) {
     let fs = ls.fs;
     let gl = ls.dyd.gt;
     let gt = gl.arr[g];
-    assert(eqstr(gt.name, label.name));
+    if (defs.LUA_USE_ASSERT) assert(eqstr(gt.name, label.name));
     if (gt.nactvar < label.nactvar) {
         let vname = getlocvar(fs, gt.nactvar).varname;
         let msg = lobject.luaO_pushfstring(ls.L, defs.to_luastring("<goto %s> at line %d jumps into the scope of local '%s'"),
@@ -482,7 +484,7 @@ const enterblock = function(fs, bl, isloop) {
     bl.upval = 0;
     bl.previous = fs.bl;
     fs.bl = bl;
-    assert(fs.freereg === fs.nactvar);
+    if (defs.LUA_USE_ASSERT) assert(fs.freereg === fs.nactvar);
 };
 
 /*
@@ -564,7 +566,7 @@ const leaveblock = function(fs) {
 
     fs.bl = bl.previous;
     removevars(fs, bl.nactvar);
-    assert(bl.nactvar === fs.nactvar);
+    if (defs.LUA_USE_ASSERT) assert(bl.nactvar === fs.nactvar);
     fs.freereg = fs.nactvar;  /* free registers */
     ls.dyd.label.n = bl.firstlabel;  /* remove local labels */
     if (bl.previous)  /* inner block? */
@@ -727,7 +729,7 @@ const constructor = function(ls, t) {
     lcode.luaK_exp2nextreg(ls.fs, t);  /* fix it at stack top */
     checknext(ls, char['{']);
     do {
-        assert(cc.v.k === expkind.VVOID || cc.tostore > 0);
+        if (defs.LUA_USE_ASSERT) assert(cc.v.k === expkind.VVOID || cc.tostore > 0);
         if (ls.t.token === char['}']) break;
         closelistfield(fs, cc);
         field(ls, cc);
@@ -829,7 +831,7 @@ const funcargs = function(ls, f, line) {
             llex.luaX_syntaxerror(ls, defs.to_luastring("function arguments expected", true));
         }
     }
-    assert(f.k === expkind.VNONRELOC);
+    if (defs.LUA_USE_ASSERT) assert(f.k === expkind.VNONRELOC);
     let nparams;
     let base = f.u.info;  /* base register for call */
     if (hasmultret(args.k))
@@ -1229,7 +1231,7 @@ const exp1 = function(ls) {
     let e = new expdesc();
     expr(ls, e);
     lcode.luaK_exp2nextreg(ls.fs, e);
-    assert(e.k === expkind.VNONRELOC);
+    if (defs.LUA_USE_ASSERT) assert(e.k === expkind.VNONRELOC);
     let reg = e.u.info;
     return reg;
 };
@@ -1449,7 +1451,7 @@ const retstat = function(ls) {
             lcode.luaK_setmultret(fs, e);
             if (e.k === expkind.VCALL && nret === 1) {  /* tail call? */
                 lopcodes.SET_OPCODE(lcode.getinstruction(fs, e), OpCodesI.OP_TAILCALL);
-                assert(lcode.getinstruction(fs, e).A === fs.nactvar);
+                if (defs.LUA_USE_ASSERT) assert(lcode.getinstruction(fs, e).A === fs.nactvar);
             }
             first = fs.nactvar;
             nret = defs.LUA_MULTRET;  /* return all values */
@@ -1459,7 +1461,7 @@ const retstat = function(ls) {
             else {
                 lcode.luaK_exp2nextreg(fs, e);  /* values must go to the stack */
                 first = fs.nactvar;  /* return all active values */
-                assert(nret === fs.freereg - first);
+                if (defs.LUA_USE_ASSERT) assert(nret === fs.freereg - first);
             }
         }
     }
@@ -1530,7 +1532,7 @@ const statement = function(ls) {
         }
     }
 
-    assert(ls.fs.f.maxstacksize >= ls.fs.freereg && ls.fs.freereg >= ls.fs.nactvar);
+    if (defs.LUA_USE_ASSERT) assert(ls.fs.f.maxstacksize >= ls.fs.freereg && ls.fs.freereg >= ls.fs.nactvar);
     ls.fs.freereg = ls.fs.nactvar;  /* free registers */
     leavelevel(ls);
 };
@@ -1566,9 +1568,9 @@ const luaY_parser = function(L, z, buff, dyd, name, firstchar) {
     dyd.actvar.n = dyd.gt.n = dyd.label.n = 0;
     llex.luaX_setinput(L, lexstate, z, funcstate.f.source, firstchar);
     mainfunc(lexstate, funcstate);
-    assert(!funcstate.prev && funcstate.nups === 1 && !lexstate.fs);
+    if (defs.LUA_USE_ASSERT) assert(!funcstate.prev && funcstate.nups === 1 && !lexstate.fs);
     /* all scopes should be correctly finished */
-    assert(dyd.actvar.n === 0 && dyd.gt.n === 0 && dyd.label.n === 0);
+    if (defs.LUA_USE_ASSERT) assert(dyd.actvar.n === 0 && dyd.gt.n === 0 && dyd.label.n === 0);
     L.top--;  /* remove scanner's table */
     return cl;  /* closure is on the stack, too */
 };

--- a/src/lstate.js
+++ b/src/lstate.js
@@ -1,9 +1,10 @@
 /*jshint esversion: 6 */
 "use strict";
 
-const assert               = require('assert');
-
 const defs                 = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert = require('assert');
+
 const lobject              = require('./lobject.js');
 const ldo                  = require('./ldo.js');
 const lapi                 = require('./lapi.js');
@@ -151,7 +152,7 @@ const lua_newthread = function(L) {
     let g = L.l_G;
     let L1 = new lua_State();
     L.stack[L.top++] = new lobject.TValue(CT.LUA_TTHREAD, L1);
-    assert(L.top <= L.ci.top, "stack overflow");
+    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     preinit_thread(L1, g);
     L1.hookmask = L.hookmask;
     L1.basehookcount = L.basehookcount;

--- a/src/lstate.js
+++ b/src/lstate.js
@@ -3,7 +3,7 @@
 
 const defs                 = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert = require('assert');
+const assert = require('assert');
 
 const lobject              = require('./lobject.js');
 const ldo                  = require('./ldo.js');
@@ -152,7 +152,7 @@ const lua_newthread = function(L) {
     let g = L.l_G;
     let L1 = new lua_State();
     L.stack[L.top++] = new lobject.TValue(CT.LUA_TTHREAD, L1);
-    if (defs.LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
+    if (LUA_USE_ASSERT) assert(L.top <= L.ci.top, "stack overflow");
     preinit_thread(L1, g);
     L1.hookmask = L.hookmask;
     L1.basehookcount = L.basehookcount;

--- a/src/lstring.js
+++ b/src/lstring.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const assert = require("assert");
-
 const defs = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert = require("assert");
 
 class TString {
 
@@ -22,19 +22,19 @@ class TString {
 }
 
 const luaS_eqlngstr = function(a, b) {
-    assert(a instanceof TString);
-    assert(b instanceof TString);
+    if (defs.LUA_USE_ASSERT) assert(a instanceof TString);
+    if (defs.LUA_USE_ASSERT) assert(b instanceof TString);
     return a == b || (a.realstring.length == b.realstring.length && a.realstring.join() == b.realstring.join());
 };
 
 /* converts strings (arrays) to a consistent map key */
 const luaS_hash = function(str) {
-    assert(Array.isArray(str));
+    if (defs.LUA_USE_ASSERT) assert(Array.isArray(str));
     return str.map(e => `${e}|`).join('');
 };
 
 const luaS_hashlongstr = function(ts) {
-    assert(ts instanceof TString);
+    if (defs.LUA_USE_ASSERT) assert(ts instanceof TString);
     if(ts.hash === null) {
         ts.hash = luaS_hash(ts.getstr());
     }

--- a/src/lstring.js
+++ b/src/lstring.js
@@ -2,7 +2,7 @@
 
 const defs = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert = require("assert");
+const assert = require("assert");
 
 class TString {
 
@@ -22,19 +22,19 @@ class TString {
 }
 
 const luaS_eqlngstr = function(a, b) {
-    if (defs.LUA_USE_ASSERT) assert(a instanceof TString);
-    if (defs.LUA_USE_ASSERT) assert(b instanceof TString);
+    if (LUA_USE_ASSERT) assert(a instanceof TString);
+    if (LUA_USE_ASSERT) assert(b instanceof TString);
     return a == b || (a.realstring.length == b.realstring.length && a.realstring.join() == b.realstring.join());
 };
 
 /* converts strings (arrays) to a consistent map key */
 const luaS_hash = function(str) {
-    if (defs.LUA_USE_ASSERT) assert(Array.isArray(str));
+    if (LUA_USE_ASSERT) assert(Array.isArray(str));
     return str.map(e => `${e}|`).join('');
 };
 
 const luaS_hashlongstr = function(ts) {
-    if (defs.LUA_USE_ASSERT) assert(ts instanceof TString);
+    if (LUA_USE_ASSERT) assert(ts instanceof TString);
     if(ts.hash === null) {
         ts.hash = luaS_hash(ts.getstr());
     }

--- a/src/lstrlib.js
+++ b/src/lstrlib.js
@@ -1,12 +1,13 @@
 "use strict";
 
-const assert  = require('assert');
 const sprintf = require('sprintf-js').sprintf;
 
 const lauxlib = require('./lauxlib.js');
 const lua     = require('./lua.js');
 const luaconf = require('./luaconf.js');
 const llimit  = require('./llimit.js');
+
+if (lua.LUA_USE_ASSERT) var assert  = require('assert');
 
 const sL_ESC  = '%';
 const L_ESC   = sL_ESC.charCodeAt(0);
@@ -65,7 +66,7 @@ const str_char = function(L) {
 };
 
 const writer = function(L, b, size, B) {
-    assert(Array.isArray(b));
+    if (lua.LUA_USE_ASSERT) assert(Array.isArray(b));
     B.push(...b.slice(0, size));
     return 0;
 };
@@ -740,7 +741,7 @@ const unpackint = function(L, str, islittle, size, issigned) {
 };
 
 const unpacknum = function(L, b, islittle, size) {
-    assert(b.length >= size);
+    if (lua.LUA_USE_ASSERT) assert(b.length >= size);
 
     let dv = new DataView(new ArrayBuffer(size));
     b.forEach((e, i) => dv.setUint8(i, e, islittle));
@@ -1152,7 +1153,7 @@ const prepstate = function(ms, L, s, ls, p, lp) {
 
 const reprepstate = function(ms) {
     ms.level = 0;
-    assert(ms.matchdepth === MAXCCALLS);
+    if (lua.LUA_USE_ASSERT) assert(ms.matchdepth === MAXCCALLS);
 };
 
 const find_subarray = function(arr, subarr, from_index) {

--- a/src/lstrlib.js
+++ b/src/lstrlib.js
@@ -7,7 +7,7 @@ const lua     = require('./lua.js');
 const luaconf = require('./luaconf.js');
 const llimit  = require('./llimit.js');
 
-if (lua.LUA_USE_ASSERT) var assert  = require('assert');
+const assert  = require('assert');
 
 const sL_ESC  = '%';
 const L_ESC   = sL_ESC.charCodeAt(0);
@@ -66,7 +66,7 @@ const str_char = function(L) {
 };
 
 const writer = function(L, b, size, B) {
-    if (lua.LUA_USE_ASSERT) assert(Array.isArray(b));
+    if (LUA_USE_ASSERT) assert(Array.isArray(b));
     B.push(...b.slice(0, size));
     return 0;
 };
@@ -741,7 +741,7 @@ const unpackint = function(L, str, islittle, size, issigned) {
 };
 
 const unpacknum = function(L, b, islittle, size) {
-    if (lua.LUA_USE_ASSERT) assert(b.length >= size);
+    if (LUA_USE_ASSERT) assert(b.length >= size);
 
     let dv = new DataView(new ArrayBuffer(size));
     b.forEach((e, i) => dv.setUint8(i, e, islittle));
@@ -1153,7 +1153,7 @@ const prepstate = function(ms, L, s, ls, p, lp) {
 
 const reprepstate = function(ms) {
     ms.level = 0;
-    if (lua.LUA_USE_ASSERT) assert(ms.matchdepth === MAXCCALLS);
+    if (LUA_USE_ASSERT) assert(ms.matchdepth === MAXCCALLS);
 };
 
 const find_subarray = function(arr, subarr, from_index) {

--- a/src/ltable.js
+++ b/src/ltable.js
@@ -3,7 +3,7 @@
 
 const defs    = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert = require('assert');
+const assert = require('assert');
 
 const ldebug  = require('./ldebug.js');
 const lobject = require('./lobject.js');
@@ -97,17 +97,17 @@ const getgeneric = function(t, hash) {
 };
 
 const luaH_getint = function(t, key) {
-    if (defs.LUA_USE_ASSERT) assert(typeof key == "number" && (key|0) === key);
+    if (LUA_USE_ASSERT) assert(typeof key == "number" && (key|0) === key);
     return getgeneric(t, key);
 };
 
 const luaH_getstr = function(t, key) {
-    if (defs.LUA_USE_ASSERT) assert(key instanceof lstring.TString);
+    if (LUA_USE_ASSERT) assert(key instanceof lstring.TString);
     return getgeneric(t, lstring.luaS_hashlongstr(key));
 };
 
 const luaH_get = function(t, key) {
-    if (defs.LUA_USE_ASSERT) assert(key instanceof lobject.TValue);
+    if (LUA_USE_ASSERT) assert(key instanceof lobject.TValue);
     if (key.ttisnil())
         return lobject.luaO_nilobject;
     return getgeneric(t, table_hash(key));
@@ -124,7 +124,7 @@ const setgeneric = function(t, hash, key) {
 };
 
 const luaH_setint = function(t, key, value) {
-    if (defs.LUA_USE_ASSERT) assert(typeof key == "number" && (key|0) === key && value instanceof lobject.TValue);
+    if (LUA_USE_ASSERT) assert(typeof key == "number" && (key|0) === key && value instanceof lobject.TValue);
     let hash = key; /* table_hash known result */
     if (value.ttisnil()) {
         mark_dead(t, hash);
@@ -142,13 +142,13 @@ const luaH_setint = function(t, key, value) {
 };
 
 const luaH_set = function(t, key) {
-    if (defs.LUA_USE_ASSERT) assert(key instanceof lobject.TValue);
+    if (LUA_USE_ASSERT) assert(key instanceof lobject.TValue);
     let hash = table_hash(key);
     return setgeneric(t, hash, new lobject.TValue(key.type, key.value));
 };
 
 const luaH_delete = function(t, key) {
-    if (defs.LUA_USE_ASSERT) assert(key instanceof lobject.TValue);
+    if (LUA_USE_ASSERT) assert(key instanceof lobject.TValue);
     let hash = table_hash(key);
     return mark_dead(t, hash);
 };

--- a/src/ltable.js
+++ b/src/ltable.js
@@ -1,9 +1,10 @@
 /*jshint esversion: 6 */
 "use strict";
 
-const assert = require('assert');
-
 const defs    = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert = require('assert');
+
 const ldebug  = require('./ldebug.js');
 const lobject = require('./lobject.js');
 const lstring = require('./lstring.js');
@@ -96,17 +97,17 @@ const getgeneric = function(t, hash) {
 };
 
 const luaH_getint = function(t, key) {
-    assert(typeof key == "number" && (key|0) === key);
+    if (defs.LUA_USE_ASSERT) assert(typeof key == "number" && (key|0) === key);
     return getgeneric(t, key);
 };
 
 const luaH_getstr = function(t, key) {
-    assert(key instanceof lstring.TString);
+    if (defs.LUA_USE_ASSERT) assert(key instanceof lstring.TString);
     return getgeneric(t, lstring.luaS_hashlongstr(key));
 };
 
 const luaH_get = function(t, key) {
-    assert(key instanceof lobject.TValue);
+    if (defs.LUA_USE_ASSERT) assert(key instanceof lobject.TValue);
     if (key.ttisnil())
         return lobject.luaO_nilobject;
     return getgeneric(t, table_hash(key));
@@ -123,7 +124,7 @@ const setgeneric = function(t, hash, key) {
 };
 
 const luaH_setint = function(t, key, value) {
-    assert(typeof key == "number" && (key|0) === key && value instanceof lobject.TValue);
+    if (defs.LUA_USE_ASSERT) assert(typeof key == "number" && (key|0) === key && value instanceof lobject.TValue);
     let hash = key; /* table_hash known result */
     if (value.ttisnil()) {
         mark_dead(t, hash);
@@ -141,13 +142,13 @@ const luaH_setint = function(t, key, value) {
 };
 
 const luaH_set = function(t, key) {
-    assert(key instanceof lobject.TValue);
+    if (defs.LUA_USE_ASSERT) assert(key instanceof lobject.TValue);
     let hash = table_hash(key);
     return setgeneric(t, hash, new lobject.TValue(key.type, key.value));
 };
 
 const luaH_delete = function(t, key) {
-    assert(key instanceof lobject.TValue);
+    if (defs.LUA_USE_ASSERT) assert(key instanceof lobject.TValue);
     let hash = table_hash(key);
     return mark_dead(t, hash);
 };

--- a/src/ltablib.js
+++ b/src/ltablib.js
@@ -1,10 +1,10 @@
 "use strict";
 
-const assert  = require('assert');
-
 const lua     = require('./lua.js');
 const lauxlib = require('./lauxlib.js');
 const llimit  = require('./llimit.js');
+
+if (lua.LUA_USE_ASSERT) var assert  = require('assert');
 
 
 /*
@@ -233,7 +233,7 @@ const partition = function(L, lo, up) {
 const choosePivot = function(lo, up, rnd) {
     let r4 = Math.floor((up - lo) / 4);  /* range/4 */
     let p = rnd % (r4 * 2) + (lo + r4);
-    assert(lo + r4 <= p && p <= up - r4);
+    if (lua.LUA_USE_ASSERT) assert(lo + r4 <= p && p <= up - r4);
     return p;
 };
 

--- a/src/ltablib.js
+++ b/src/ltablib.js
@@ -4,7 +4,7 @@ const lua     = require('./lua.js');
 const lauxlib = require('./lauxlib.js');
 const llimit  = require('./llimit.js');
 
-if (lua.LUA_USE_ASSERT) var assert  = require('assert');
+const assert  = require('assert');
 
 
 /*
@@ -233,7 +233,7 @@ const partition = function(L, lo, up) {
 const choosePivot = function(lo, up, rnd) {
     let r4 = Math.floor((up - lo) / 4);  /* range/4 */
     let p = rnd % (r4 * 2) + (lo + r4);
-    if (lua.LUA_USE_ASSERT) assert(lo + r4 <= p && p <= up - r4);
+    if (LUA_USE_ASSERT) assert(lo + r4 <= p && p <= up - r4);
     return p;
 };
 

--- a/src/ltm.js
+++ b/src/ltm.js
@@ -1,9 +1,10 @@
 /*jshint esversion: 6 */
 "use strict";
 
-const assert  = require('assert');
-
 const defs    = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert  = require('assert');
+
 const lobject = require('./lobject.js');
 const ldo     = require('./ldo.js');
 const lstate  = require('./lstate.js');
@@ -124,7 +125,7 @@ const luaT_callTM = function(L, f, p1, p2, p3, hasres) {
         ldo.luaD_callnoyield(L, func, hasres);
 
     if (hasres) {
-        assert(typeof result === "number");
+        if (defs.LUA_USE_ASSERT) assert(typeof result === "number");
         L.stack[result] = L.stack[--L.top];
     }
 };

--- a/src/ltm.js
+++ b/src/ltm.js
@@ -3,7 +3,7 @@
 
 const defs    = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert  = require('assert');
+const assert  = require('assert');
 
 const lobject = require('./lobject.js');
 const ldo     = require('./ldo.js');
@@ -125,7 +125,7 @@ const luaT_callTM = function(L, f, p1, p2, p3, hasres) {
         ldo.luaD_callnoyield(L, func, hasres);
 
     if (hasres) {
-        if (defs.LUA_USE_ASSERT) assert(typeof result === "number");
+        if (LUA_USE_ASSERT) assert(typeof result === "number");
         L.stack[result] = L.stack[--L.top];
     }
 };

--- a/src/lua.js
+++ b/src/lua.js
@@ -76,6 +76,7 @@ module.exports.LUA_VERSION_MINOR       = defs.LUA_VERSION_MINOR;
 module.exports.LUA_VERSION_NUM         = defs.LUA_VERSION_NUM;
 module.exports.LUA_VERSION_RELEASE     = defs.LUA_VERSION_RELEASE;
 module.exports.LUA_VERSUFFIX           = defs.LUA_VERSUFFIX;
+module.exports.LUA_USE_ASSERT          = defs.LUA_USE_ASSERT;
 module.exports.LUA_YIELD               = defs.thread_status.LUA_YIELD;
 module.exports.lua_Debug               = defs.lua_Debug;
 module.exports.lua_upvalueindex        = defs.lua_upvalueindex;

--- a/src/lundump.js
+++ b/src/lundump.js
@@ -3,7 +3,7 @@
 
 const defs     = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert  = require('assert');
+const assert  = require('assert');
 
 const ldo      = require('./ldo.js');
 const lfunc    = require('./lfunc.js');
@@ -23,8 +23,8 @@ class BytecodeParser {
         this.integerSize = 4;
         this.numberSize = 8;
 
-        if (defs.LUA_USE_ASSERT) assert(Z instanceof lzio.ZIO, "BytecodeParser only operates on a ZIO");
-        if (defs.LUA_USE_ASSERT) assert(Array.isArray(name));
+        if (LUA_USE_ASSERT) assert(Z instanceof lzio.ZIO, "BytecodeParser only operates on a ZIO");
+        if (LUA_USE_ASSERT) assert(Array.isArray(name));
 
         if (name[0] == defs.char["@"] || name[0] == defs.char["="])
             this.name = name.slice(1);
@@ -269,7 +269,7 @@ const luaU_undump = function(L, Z, name) {
     L.stack[L.top++] = new lobject.TValue(defs.CT.LUA_TLCL, cl);
     cl.p = new lfunc.Proto(L);
     S.readFunction(cl.p, null);
-    if (defs.LUA_USE_ASSERT) assert(cl.nupvalues === cl.p.upvalues.length);
+    if (LUA_USE_ASSERT) assert(cl.nupvalues === cl.p.upvalues.length);
     /* luai_verifycode */
     return cl;
 };

--- a/src/lundump.js
+++ b/src/lundump.js
@@ -1,9 +1,10 @@
 /*jshint esversion: 6 */
 "use strict";
 
-const assert  = require('assert');
-
 const defs     = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert  = require('assert');
+
 const ldo      = require('./ldo.js');
 const lfunc    = require('./lfunc.js');
 const lobject  = require('./lobject.js');
@@ -22,8 +23,8 @@ class BytecodeParser {
         this.integerSize = 4;
         this.numberSize = 8;
 
-        assert(Z instanceof lzio.ZIO, "BytecodeParser only operates on a ZIO");
-        assert(Array.isArray(name));
+        if (defs.LUA_USE_ASSERT) assert(Z instanceof lzio.ZIO, "BytecodeParser only operates on a ZIO");
+        if (defs.LUA_USE_ASSERT) assert(Array.isArray(name));
 
         if (name[0] == defs.char["@"] || name[0] == defs.char["="])
             this.name = name.slice(1);
@@ -268,7 +269,7 @@ const luaU_undump = function(L, Z, name) {
     L.stack[L.top++] = new lobject.TValue(defs.CT.LUA_TLCL, cl);
     cl.p = new lfunc.Proto(L);
     S.readFunction(cl.p, null);
-    assert(cl.nupvalues === cl.p.upvalues.length);
+    if (defs.LUA_USE_ASSERT) assert(cl.nupvalues === cl.p.upvalues.length);
     /* luai_verifycode */
     return cl;
 };

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -1,9 +1,11 @@
 /*jshint esversion: 6 */
 "use strict";
 
-const assert         = require('assert');
 
 const defs        = require('./defs.js');
+
+if (defs.LUA_USE_ASSERT) var assert = require('assert');
+
 const lopcodes    = require('./lopcodes.js');
 const luaconf     = require('./luaconf.js');
 const lobject     = require('./lobject.js');
@@ -41,11 +43,11 @@ const luaV_finishOp = function(L) {
             let res = !L.stack[L.top - 1].l_isfalse();
             L.top--;
             if (ci.callstatus & lstate.CIST_LEQ) {  /* "<=" using "<" instead? */
-                assert(op === OCi.OP_LE);
+                if (defs.LUA_USE_ASSERT) assert(op === OCi.OP_LE);
                 ci.callstatus ^= lstate.CIST_LEQ;  /* clear mark */
                 res = res !== 1 ? 1 : 0;  /* negate result */
             }
-            assert(ci.l_code[ci.l_savedpc] === OCi.OP_JMP);
+            if (defs.LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc] === OCi.OP_JMP);
             if (res !== inst.A)  /* condition failed? */
                 ci.l_savedpc++;  /* skip jump instruction */
             break;
@@ -66,7 +68,7 @@ const luaV_finishOp = function(L) {
             break;
         }
         case OCi.OP_TFORCALL: {
-            assert(ci.l_code[ci.l_savedpc] === OCi.OP_TFORLOOP);
+            if (defs.LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc] === OCi.OP_TFORLOOP);
             L.top = ci.top;  /* correct top */
             break;
         }
@@ -105,7 +107,7 @@ const luaV_execute = function(L) {
     ci.callstatus |= lstate.CIST_FRESH;
     newframe:
     for (;;) {
-        assert(ci === L.ci);
+        if (defs.LUA_USE_ASSERT) assert(ci === L.ci);
         let cl = ci.func.value;
         let k = cl.p.k;
         let base = ci.l_base;
@@ -130,7 +132,7 @@ const luaV_execute = function(L) {
                 break;
             }
             case OCi.OP_LOADKX: {
-                assert(ci.l_code[ci.l_savedpc].opcode === OCi.OP_EXTRAARG);
+                if (defs.LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc].opcode === OCi.OP_EXTRAARG);
                 let konst = k[ci.l_code[ci.l_savedpc++].Ax];
                 L.stack[ra] = new lobject.TValue(konst.type, konst.value);
                 break;
@@ -496,7 +498,7 @@ const luaV_execute = function(L) {
                     oci.next = null;
                     ci = L.ci = oci;
 
-                    assert(L.top === oci.l_base + L.stack[ofuncOff].value.p.maxstacksize);
+                    if (defs.LUA_USE_ASSERT) assert(L.top === oci.l_base + L.stack[ofuncOff].value.p.maxstacksize);
 
                     continue newframe;
                 }
@@ -587,7 +589,7 @@ const luaV_execute = function(L) {
                 L.top = ci.top;
                 i = ci.l_code[ci.l_savedpc++];
                 ra = RA(L, base, i);
-                assert(i.opcode === OCi.OP_TFORLOOP);
+                if (defs.LUA_USE_ASSERT) assert(i.opcode === OCi.OP_TFORLOOP);
                 /* fall through */
             }
             case OCi.OP_TFORLOOP: {
@@ -604,7 +606,7 @@ const luaV_execute = function(L) {
                 if (n === 0) n = L.top - ra - 1;
 
                 if (c === 0) {
-                    assert(ci.l_code[ci.l_savedpc].opcode === OCi.OP_EXTRAARG);
+                    if (defs.LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc].opcode === OCi.OP_EXTRAARG);
                     c = ci.l_code[ci.l_savedpc++].Ax;
                 }
 
@@ -955,7 +957,7 @@ const isemptystr = function(o) {
 ** from 'L->top - total' up to 'L->top - 1'.
 */
 const luaV_concat = function(L, total) {
-    assert(total >= 2);
+    if (defs.LUA_USE_ASSERT) assert(total >= 2);
     do {
         let top = L.top;
         let n = 2; /* number of elements handled in this pass (at least 2) */
@@ -1014,12 +1016,12 @@ const gettable = function(L, table, key, ra, recur) {
 const luaV_finishget = function(L, t, key, val, slot, recur) {
     let tm;
     if (slot === null) { /* 't' is not a table? */
-        assert(!t.ttistable());
+        if (defs.LUA_USE_ASSERT) assert(!t.ttistable());
         tm = ltm.luaT_gettmbyobj(L, t, ltm.TMS.TM_INDEX);
         if (tm.ttisnil())
             ldebug.luaG_typeerror(L, t, defs.to_luastring('index', true));
     } else { /* 't' is a table */
-        assert(slot.ttisnil());
+        if (defs.LUA_USE_ASSERT) assert(slot.ttisnil());
         tm = ltm.luaT_gettmbyobj(L, t, ltm.TMS.TM_INDEX); // TODO: fasttm
         if (tm.ttisnil()) {
             L.stack[val] = new lobject.TValue(CT.LUA_TNIL, null);
@@ -1060,7 +1062,7 @@ const settable = function(L, table, key, v, recur) {
 const luaV_finishset = function(L, t, key, val, slot, recur) {
     let tm;
     if (slot !== null) { /* is 't' a table? */
-        assert(slot.ttisnil());
+        if (defs.LUA_USE_ASSERT) assert(slot.ttisnil());
         tm = ltm.luaT_gettmbyobj(L, t, ltm.TMS.TM_NEWINDEX); // TODO: fasttm
         if (tm.ttisnil()) {
             if (val.ttisnil())

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -4,7 +4,7 @@
 
 const defs        = require('./defs.js');
 
-if (defs.LUA_USE_ASSERT) var assert = require('assert');
+const assert = require('assert');
 
 const lopcodes    = require('./lopcodes.js');
 const luaconf     = require('./luaconf.js');
@@ -43,11 +43,11 @@ const luaV_finishOp = function(L) {
             let res = !L.stack[L.top - 1].l_isfalse();
             L.top--;
             if (ci.callstatus & lstate.CIST_LEQ) {  /* "<=" using "<" instead? */
-                if (defs.LUA_USE_ASSERT) assert(op === OCi.OP_LE);
+                if (LUA_USE_ASSERT) assert(op === OCi.OP_LE);
                 ci.callstatus ^= lstate.CIST_LEQ;  /* clear mark */
                 res = res !== 1 ? 1 : 0;  /* negate result */
             }
-            if (defs.LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc] === OCi.OP_JMP);
+            if (LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc] === OCi.OP_JMP);
             if (res !== inst.A)  /* condition failed? */
                 ci.l_savedpc++;  /* skip jump instruction */
             break;
@@ -68,7 +68,7 @@ const luaV_finishOp = function(L) {
             break;
         }
         case OCi.OP_TFORCALL: {
-            if (defs.LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc] === OCi.OP_TFORLOOP);
+            if (LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc] === OCi.OP_TFORLOOP);
             L.top = ci.top;  /* correct top */
             break;
         }
@@ -107,7 +107,7 @@ const luaV_execute = function(L) {
     ci.callstatus |= lstate.CIST_FRESH;
     newframe:
     for (;;) {
-        if (defs.LUA_USE_ASSERT) assert(ci === L.ci);
+        if (LUA_USE_ASSERT) assert(ci === L.ci);
         let cl = ci.func.value;
         let k = cl.p.k;
         let base = ci.l_base;
@@ -132,7 +132,7 @@ const luaV_execute = function(L) {
                 break;
             }
             case OCi.OP_LOADKX: {
-                if (defs.LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc].opcode === OCi.OP_EXTRAARG);
+                if (LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc].opcode === OCi.OP_EXTRAARG);
                 let konst = k[ci.l_code[ci.l_savedpc++].Ax];
                 L.stack[ra] = new lobject.TValue(konst.type, konst.value);
                 break;
@@ -498,7 +498,7 @@ const luaV_execute = function(L) {
                     oci.next = null;
                     ci = L.ci = oci;
 
-                    if (defs.LUA_USE_ASSERT) assert(L.top === oci.l_base + L.stack[ofuncOff].value.p.maxstacksize);
+                    if (LUA_USE_ASSERT) assert(L.top === oci.l_base + L.stack[ofuncOff].value.p.maxstacksize);
 
                     continue newframe;
                 }
@@ -589,7 +589,7 @@ const luaV_execute = function(L) {
                 L.top = ci.top;
                 i = ci.l_code[ci.l_savedpc++];
                 ra = RA(L, base, i);
-                if (defs.LUA_USE_ASSERT) assert(i.opcode === OCi.OP_TFORLOOP);
+                if (LUA_USE_ASSERT) assert(i.opcode === OCi.OP_TFORLOOP);
                 /* fall through */
             }
             case OCi.OP_TFORLOOP: {
@@ -606,7 +606,7 @@ const luaV_execute = function(L) {
                 if (n === 0) n = L.top - ra - 1;
 
                 if (c === 0) {
-                    if (defs.LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc].opcode === OCi.OP_EXTRAARG);
+                    if (LUA_USE_ASSERT) assert(ci.l_code[ci.l_savedpc].opcode === OCi.OP_EXTRAARG);
                     c = ci.l_code[ci.l_savedpc++].Ax;
                 }
 
@@ -957,7 +957,7 @@ const isemptystr = function(o) {
 ** from 'L->top - total' up to 'L->top - 1'.
 */
 const luaV_concat = function(L, total) {
-    if (defs.LUA_USE_ASSERT) assert(total >= 2);
+    if (LUA_USE_ASSERT) assert(total >= 2);
     do {
         let top = L.top;
         let n = 2; /* number of elements handled in this pass (at least 2) */
@@ -1016,12 +1016,12 @@ const gettable = function(L, table, key, ra, recur) {
 const luaV_finishget = function(L, t, key, val, slot, recur) {
     let tm;
     if (slot === null) { /* 't' is not a table? */
-        if (defs.LUA_USE_ASSERT) assert(!t.ttistable());
+        if (LUA_USE_ASSERT) assert(!t.ttistable());
         tm = ltm.luaT_gettmbyobj(L, t, ltm.TMS.TM_INDEX);
         if (tm.ttisnil())
             ldebug.luaG_typeerror(L, t, defs.to_luastring('index', true));
     } else { /* 't' is a table */
-        if (defs.LUA_USE_ASSERT) assert(slot.ttisnil());
+        if (LUA_USE_ASSERT) assert(slot.ttisnil());
         tm = ltm.luaT_gettmbyobj(L, t, ltm.TMS.TM_INDEX); // TODO: fasttm
         if (tm.ttisnil()) {
             L.stack[val] = new lobject.TValue(CT.LUA_TNIL, null);
@@ -1062,7 +1062,7 @@ const settable = function(L, table, key, v, recur) {
 const luaV_finishset = function(L, t, key, val, slot, recur) {
     let tm;
     if (slot !== null) { /* is 't' a table? */
-        if (defs.LUA_USE_ASSERT) assert(slot.ttisnil());
+        if (LUA_USE_ASSERT) assert(slot.ttisnil());
         tm = ltm.luaT_gettmbyobj(L, t, ltm.TMS.TM_NEWINDEX); // TODO: fasttm
         if (tm.ttisnil()) {
             if (val.ttisnil())

--- a/src/lzio.js
+++ b/src/lzio.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const assert = require('assert');
-
+const defs = require('./defs.js');
+if (defs.LUA_USE_ASSERT) var assert = require('assert');
 
 class MBuffer {
     constructor() {
@@ -13,7 +13,7 @@ class MBuffer {
 class ZIO {
     constructor(L, reader, data) {
         this.L = L;           /* Lua state (for reader) */
-        assert(typeof reader == "function", "ZIO requires a reader");
+        if (defs.LUA_USE_ASSERT) assert(typeof reader == "function", "ZIO requires a reader");
         this.reader = reader; /* reader function */
         this.data = data;     /* additional data */
         this.n = 0;           /* bytes still unread */
@@ -38,7 +38,7 @@ const luaZ_fill = function(z) {
         z.off = 0;
         size = buff.byteLength - buff.byteOffset;
     } else {
-        assert(typeof buff !== "string", "Should only load binary of array of bytes");
+        if (defs.LUA_USE_ASSERT) assert(typeof buff !== "string", "Should only load binary of array of bytes");
         z.buffer = buff;
         z.off = 0;
         size = buff.length;

--- a/src/lzio.js
+++ b/src/lzio.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const defs = require('./defs.js');
-if (defs.LUA_USE_ASSERT) var assert = require('assert');
+const assert = require('assert');
 
 class MBuffer {
     constructor() {
@@ -13,7 +12,7 @@ class MBuffer {
 class ZIO {
     constructor(L, reader, data) {
         this.L = L;           /* Lua state (for reader) */
-        if (defs.LUA_USE_ASSERT) assert(typeof reader == "function", "ZIO requires a reader");
+        if (LUA_USE_ASSERT) assert(typeof reader == "function", "ZIO requires a reader");
         this.reader = reader; /* reader function */
         this.data = data;     /* additional data */
         this.n = 0;           /* bytes still unread */
@@ -38,7 +37,7 @@ const luaZ_fill = function(z) {
         z.off = 0;
         size = buff.byteLength - buff.byteOffset;
     } else {
-        if (defs.LUA_USE_ASSERT) assert(typeof buff !== "string", "Should only load binary of array of bytes");
+        if (LUA_USE_ASSERT) assert(typeof buff !== "string", "Should only load binary of array of bytes");
         z.buffer = buff;
         z.off = 0;
         size = buff.length;

--- a/tests/lcorolib.js
+++ b/tests/lcorolib.js
@@ -2,6 +2,8 @@
 
 const test       = require('tape');
 
+global.WEB    = false;
+
 const lua     = require('../src/lua.js');
 const lauxlib = require('../src/lauxlib.js');
 const lualib  = require('../src/lualib.js');

--- a/tests/manual-tests/lua-cli.js
+++ b/tests/manual-tests/lua-cli.js
@@ -1,7 +1,8 @@
-//#!/usr/bin/env node
+#!/usr/bin/env node
 "use strict";
 
 global.WEB = false;
+global.LUA_USE_ASSERT = false;
 
 const lua          = require('../../src/lua.js');
 const lauxlib      = require('../../src/lauxlib.js');

--- a/tests/manual-tests/lua-cli.js
+++ b/tests/manual-tests/lua-cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+//#!/usr/bin/env node
 "use strict";
 
 global.WEB = false;
@@ -186,7 +186,7 @@ if (!has_E) {
             status = dostring(L, init, name);
         }
         if (status !== lua.LUA_OK) {
-            return process.exit(1);
+            process.exit(1);
         }
     }
 }
@@ -205,7 +205,7 @@ for (let i = 1; i < script; i++) {
             status = dolibrary(L, extra);
         }
         if (status !== lua.LUA_OK) {
-            return process.exit(1);
+            process.exit(1);
         }
     }
 }

--- a/tests/test-suite/attrib.js
+++ b/tests/test-suite/attrib.js
@@ -3,6 +3,7 @@
 const test     = require('tape');
 
 global.WEB = false;
+global.LUA_USE_ASSERT = true;
 
 const lua     = require('../../src/lua.js');
 const lauxlib = require('../../src/lauxlib.js');

--- a/tests/test-suite/calls.js
+++ b/tests/test-suite/calls.js
@@ -3,6 +3,7 @@
 const test     = require('tape');
 
 global.WEB = false;
+global.LUA_USE_ASSERT = true;
 
 const lua     = require('../../src/lua.js');
 const lauxlib = require('../../src/lauxlib.js');

--- a/tests/test-suite/constructs.js
+++ b/tests/test-suite/constructs.js
@@ -3,6 +3,7 @@
 const test     = require('tape');
 
 global.WEB = false;
+global.LUA_USE_ASSERT = true;
 
 const lua     = require('../../src/lua.js');
 const lauxlib = require('../../src/lauxlib.js');

--- a/tests/test-suite/events.js
+++ b/tests/test-suite/events.js
@@ -3,6 +3,7 @@
 const test     = require('tape');
 
 global.WEB = false;
+global.LUA_USE_ASSERT = true;
 
 const lua     = require('../../src/lua.js');
 const lauxlib = require('../../src/lauxlib.js');

--- a/tests/test-suite/literals.js
+++ b/tests/test-suite/literals.js
@@ -3,6 +3,7 @@
 const test     = require('tape');
 
 global.WEB = false;
+global.LUA_USE_ASSERT = true;
 
 const lua     = require('../../src/lua.js');
 const lauxlib = require('../../src/lauxlib.js');

--- a/tests/test-suite/locals.js
+++ b/tests/test-suite/locals.js
@@ -3,6 +3,7 @@
 const test     = require('tape');
 
 global.WEB = false;
+global.LUA_USE_ASSERT = true;
 
 const lua     = require('../../src/lua.js');
 const lauxlib = require('../../src/lauxlib.js');

--- a/tests/test-suite/ltests.js
+++ b/tests/test-suite/ltests.js
@@ -1,6 +1,7 @@
 "use strict";
 
 global.WEB = false;
+global.LUA_USE_ASSERT = true;
 
 const lua     = require('../../src/lua.js');
 const lauxlib = require('../../src/lauxlib.js');

--- a/tests/test-suite/strings.js
+++ b/tests/test-suite/strings.js
@@ -3,6 +3,7 @@
 const test     = require('tape');
 
 global.WEB = false;
+global.LUA_USE_ASSERT = true;
 
 const lua     = require('../../src/lua.js');
 const lauxlib = require('../../src/lauxlib.js');

--- a/tests/test-suite/vararg.js
+++ b/tests/test-suite/vararg.js
@@ -3,6 +3,7 @@
 const test     = require('tape');
 
 global.WEB = false;
+global.LUA_USE_ASSERT = true;
 
 const lua     = require('../../src/lua.js');
 const lauxlib = require('../../src/lauxlib.js');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,6 +1,7 @@
 "use strict";
 
 global.WEB = false;
+global.LUA_USE_ASSERT = true;
 
 const fs             = require('fs');
 const child_process  = require('child_process');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = [
         plugins: [
             new webpack.DefinePlugin({
                 WEB: JSON.stringify(true),
+                LUA_USE_ASSERT: false
             })
         ]
     },
@@ -27,6 +28,7 @@ module.exports = [
             new BabiliPlugin(),
             new webpack.DefinePlugin({
                 WEB: JSON.stringify(true),
+                LUA_USE_ASSERT: false
             })
         ]
     }


### PR DESCRIPTION
Needs to be a global for babili to remove the dead code.

TODO: run babili outside of webpack for the node version