### PR TITLE
Modify stack TValues instead of assigning new TValues

### DIFF
--- a/src/lapi.js
+++ b/src/lapi.js
@@ -1046,7 +1046,7 @@ const lua_concat = function(L, n) {
     if (n >= 2)
         lvm.luaV_concat(L, n);
     else if (n === 0) {
-        lobject.setsvalue2s(L, L.top, lstring.luaS_newliteral(L, []));
+        lobject.setsvalue2s(L, L.top, lstring.luaS_bless(L, []));
         L.top++;
         assert(L.top <= L.ci.top, "stack overflow");
     }

--- a/src/lapi.js
+++ b/src/lapi.js
@@ -255,6 +255,7 @@ const lua_pushstring = function (L, s) {
     else {
         let ts = lstring.luaS_new(L, s);
         lobject.setsvalue2s(L, L.top, ts);
+        s = ts.getstr(); /* internal copy */
     }
     L.top++;
     assert(L.top <= L.ci.top, "stack overflow");

--- a/src/lapi.js
+++ b/src/lapi.js
@@ -272,16 +272,17 @@ const lua_pushfstring = function (L, fmt, ...argp) {
     return lobject.luaO_pushvfstring(L, fmt, argp);
 };
 
+/* Similar to lua_pushstring, but takes a JS string */
 const lua_pushliteral = function (L, s) {
     assert(typeof s === "string" || s === undefined || s === null, "lua_pushliteral expects a JS string");
 
     if (s === undefined || s === null)
         L.stack[L.top] = new TValue(CT.LUA_TNIL, null);
     else {
-        let ts = new TValue(CT.LUA_TLNGSTR, lstring.luaS_newliteral(L, s));
-        L.stack[L.top] = ts;
+        let ts = lstring.luaS_newliteral(L, s);
+        lobject.setsvalue2s(L, L.top, ts);
+        s = ts.getstr(); /* internal copy */
     }
-
     L.top++;
     assert(L.top <= L.ci.top, "stack overflow");
 

--- a/src/lapi.js
+++ b/src/lapi.js
@@ -1060,8 +1060,9 @@ const lua_concat = function(L, n) {
 
 const lua_len = function(L, idx) {
     let t = index2addr(L, idx);
-    L.stack[L.top] = new TValue();
-    lvm.luaV_objlen(L, L.stack[L.top], t);
+    let tv = new TValue();
+    lvm.luaV_objlen(L, tv, t);
+    L.stack[L.top] = tv;
     L.top++;
     assert(L.top <= L.ci.top, "stack overflow");
 };

--- a/src/lapi.js
+++ b/src/lapi.js
@@ -163,7 +163,7 @@ const lua_pop = function(L, n) {
 const reverse = function(L, from, to) {
     for (; from < to; from++, to--) {
         let temp = L.stack[from];
-        L.stack[from] = L.stack[to];
+        lobject.setobjs2s(L, from, to);
         L.stack[to] = temp;
     }
 };
@@ -892,7 +892,8 @@ const lua_arith = function(L, op) {
         assert(2 < L.top - L.ci.funcOff, "not enough elements in the stack");  /* all other operations expect two operands */
     else {  /* for unary operations, add fake 2nd operand */
         assert(1 < L.top - L.ci.funcOff, "not enough elements in the stack");
-        L.stack[L.top++] = L.stack[L.top - 1];
+        lobject.setobjs2s(L, L.top, L.top - 1);
+        L.top++;
     }
     /* first operand at top - 2, second at top - 1; result go to top - 2 */
     lobject.luaO_arith(L, op, L.stack[L.top - 2], L.stack[L.top - 1], L.stack[L.top - 2]);

--- a/src/lapi.js
+++ b/src/lapi.js
@@ -232,10 +232,14 @@ const lua_pushinteger = function(L, n) {
 };
 
 const lua_pushlstring = function(L, s, len) {
-    assert(Array.isArray(s), "lua_pushlstring expects array of byte");
     assert(typeof len === "number");
-
-    let ts = lstring.luaS_bless(L, s.slice(0, len));
+    let ts;
+    if (len === 0) {
+        ts = lstring.luaS_bless(L, []);
+    } else {
+        assert(Array.isArray(s), "lua_pushlstring expects array of byte");
+        ts = lstring.luaS_bless(L, s.slice(0, len));
+    }
     lobject.setsvalue2s(L, L.top, ts);
     L.top++;
     assert(L.top <= L.ci.top, "stack overflow");

--- a/src/ldebug.js
+++ b/src/ldebug.js
@@ -155,7 +155,7 @@ const lua_setlocal = function(L, ar, n) {
     let name = local.name;
     let pos = local.pos;
     if (name) {
-        L.stack[pos] = L.stack[L.top - 1];
+        lobject.setobjs2s(L, pos, L.top - 1);
         delete L.stack[--L.top];  /* pop value */
     }
     swapextra(L);
@@ -280,7 +280,8 @@ const lua_getinfo = function(L, what, ar) {
     cl = func.ttisclosure() ? func.value : null;
     status = auxgetinfo(L, what, ar, cl, ci);
     if (what.indexOf('f'.charCodeAt(0)) >= 0) {
-        L.stack[L.top++] = func;
+        lobject.setobjs2s(L, L.top, funcOff);
+        L.top++;
         assert(L.top <= L.ci.top, "stack overflow");
     }
 
@@ -590,8 +591,8 @@ const luaG_runerror = function(L, fmt, ...argp) {
 const luaG_errormsg = function(L) {
     if (L.errfunc !== 0) {  /* is there an error handling function? */
         let errfunc = L.errfunc;
-        L.stack[L.top] = L.stack[L.top - 1];
-        L.stack[L.top - 1] = L.stack[errfunc];
+        lobject.setobjs2s(L, L.top, L.top - 1); /* move argument */
+        lobject.setobjs2s(L, L.top - 1, errfunc); /* push function */
         L.top++;
         ldo.luaD_callnoyield(L, L.top - 2, 1);
     }

--- a/src/ldebug.js
+++ b/src/ldebug.js
@@ -183,12 +183,14 @@ const funcinfo = function(ar, cl) {
 
 const collectvalidlines = function(L, f) {
     if (f === null || f instanceof lobject.CClosure) {
-        L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+        L.stack[L.top] = new lobject.TValue(CT.LUA_TNIL, null);
+        L.top++;
         assert(L.top <= L.ci.top, "stack overflow");
     } else {
         let lineinfo = f.l.p.lineinfo;
         let t = ltable.luaH_new(L);
-        L.stack[L.top++] = new lobject.TValue(CT.LUA_TTABLE, t);
+        L.stack[L.top] = new lobject.TValue(CT.LUA_TTABLE, t);
+        L.top++;
         assert(L.top <= L.ci.top, "stack overflow");
         let v = new lobject.TValue(CT.LUA_TBOOLEAN, true);
         for (let i = 0; i < f.l.p.length; i++)

--- a/src/ldebug.js
+++ b/src/ldebug.js
@@ -140,7 +140,9 @@ const lua_getlocal = function(L, ar, n) {
         let local = findlocal(L, ar.i_ci, n);
         if (local) {
             name = local.name;
-            L.stack[L.top++] = L.stack[local.pos];
+            lobject.setobj2s(L, L.top, L.stack[local.pos]);
+            L.top++;
+            assert(L.top <= L.ci.top, "stack overflow");
         } else {
             name = null;
         }

--- a/src/ldo.js
+++ b/src/ldo.js
@@ -270,7 +270,7 @@ const tryfuncTM = function(L, off, func) {
     for (let p = L.top; p > off; p--)
         lobject.setobjs2s(L, p, p-1);
     L.top++; /* slot ensured by caller */
-    L.stack[off] = new lobject.TValue(tm.type, tm.value); /* tag method is the new function to be called */
+    lobject.setobj2s(L, off, tm); /* tag method is the new function to be called */
 };
 
 /*

--- a/src/ldo.js
+++ b/src/ldo.js
@@ -693,8 +693,6 @@ const luaD_protectedparser = function(L, z, name, mode) {
     return status;
 };
 
-module.exports.SParser              = SParser;
-module.exports.adjust_varargs       = adjust_varargs;
 module.exports.luaD_call            = luaD_call;
 module.exports.luaD_callnoyield     = luaD_callnoyield;
 module.exports.luaD_checkstack      = luaD_checkstack;
@@ -712,6 +710,3 @@ module.exports.lua_isyieldable      = lua_isyieldable;
 module.exports.lua_resume           = lua_resume;
 module.exports.lua_yield            = lua_yield;
 module.exports.lua_yieldk           = lua_yieldk;
-module.exports.moveresults          = moveresults;
-module.exports.stackerror           = stackerror;
-module.exports.tryfuncTM            = tryfuncTM;

--- a/src/ldo.js
+++ b/src/ldo.js
@@ -24,11 +24,11 @@ const TS = defs.thread_status;
 const seterrorobj = function(L, errcode, oldtop) {
     switch (errcode) {
         case TS.LUA_ERRMEM: {
-            L.stack[oldtop] = new lobject.TValue(CT.LUA_TLNGSTR, lstring.luaS_newliteral(L, "not enough memory"));
+            lobject.setsvalue2s(L, oldtop, lstring.luaS_newliteral(L, "not enough memory"));
             break;
         }
         case TS.LUA_ERRERR: {
-            L.stack[oldtop] = new lobject.TValue(CT.LUA_TLNGSTR, lstring.luaS_newliteral(L, "error in error handling"));
+            lobject.setsvalue2s(L, oldtop, lstring.luaS_newliteral(L, "error in error handling"));
             break;
         }
         default: {
@@ -465,7 +465,8 @@ const recover = function(L, status) {
 */
 const resume_error = function(L, msg, narg) {
     L.top -= narg;  /* remove args from the stack */
-    L.stack[L.top++] = new lobject.TValue(CT.LUA_TLNGSTR, lstring.luaS_newliteral(L, msg));  /* push error message */
+    lobject.setsvalue2s(L, L.top, lstring.luaS_newliteral(L, msg));  /* push error message */
+    L.top++;
     assert(L.top <= L.ci.top, "stack overflow");
     return TS.LUA_ERRRUN;
 };

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -185,6 +185,11 @@ class TValue {
 
 }
 
+/* from stack to (same) stack */
+const setobjs2s = function(L, newidx, oldidx) {
+    L.stack[newidx] = L.stack[oldidx];
+};
+
 const luaO_nilobject = new TValue(CT.LUA_TNIL, null);
 Object.freeze(luaO_nilobject);
 module.exports.luaO_nilobject = luaO_nilobject;
@@ -667,3 +672,4 @@ module.exports.luaO_tostring     = luaO_tostring;
 module.exports.luaO_utf8desc     = luaO_utf8desc;
 module.exports.luaO_utf8esc      = luaO_utf8esc;
 module.exports.numarith          = numarith;
+module.exports.setobjs2s         = setobjs2s;

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -161,6 +161,31 @@ class TValue {
         this.value = x;
     }
 
+    setsvalue(x) {
+        this.type = CT.LUA_TLNGSTR; /* LUA_TSHRSTR? */
+        this.value = x;
+    }
+
+    setuvalue(x) {
+        this.type = CT.LUA_TUSERDATA;
+        this.value = x;
+    }
+
+    setthvalue(x) {
+        this.type = CT.LUA_TTHREAD;
+        this.value = x;
+    }
+
+    setclLvalue(x) {
+        this.type = CT.LUA_TLCL;
+        this.value = x;
+    }
+
+    setclCvalue(x) {
+        this.type = CT.LUA_TCCL;
+        this.value = x;
+    }
+
     sethvalue(x) {
         this.type = CT.LUA_TTABLE;
         this.value = x;

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -189,6 +189,10 @@ class TValue {
 const setobjs2s = function(L, newidx, oldidx) {
     L.stack[newidx] = L.stack[oldidx];
 };
+/* to stack (not from same stack) */
+const setobj2s = function(L, newidx, oldtv) {
+    L.stack[newidx] = new TValue(oldtv.type, oldtv.value);
+};
 
 const luaO_nilobject = new TValue(CT.LUA_TNIL, null);
 Object.freeze(luaO_nilobject);
@@ -673,3 +677,4 @@ module.exports.luaO_utf8desc     = luaO_utf8desc;
 module.exports.luaO_utf8esc      = luaO_utf8esc;
 module.exports.numarith          = numarith;
 module.exports.setobjs2s         = setobjs2s;
+module.exports.setobj2s          = setobj2s;

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -193,6 +193,9 @@ const setobjs2s = function(L, newidx, oldidx) {
 const setobj2s = function(L, newidx, oldtv) {
     L.stack[newidx] = new TValue(oldtv.type, oldtv.value);
 };
+const setsvalue2s = function(L, newidx, ts) {
+    L.stack[newidx] = new TValue(CT.LUA_TLNGSTR, ts);
+};
 
 const luaO_nilobject = new TValue(CT.LUA_TNIL, null);
 Object.freeze(luaO_nilobject);
@@ -486,12 +489,12 @@ const luaO_tostring = function(L, obj) {
             buff.push(char['0']);  /* adds '.0' to result */
         }
     }
-    return new TValue(CT.LUA_TLNGSTR, lstring.luaS_bless(L, buff));
+    return lstring.luaS_bless(L, buff);
 };
 
 const pushstr = function(L, str) {
+    setsvalue2s(L, L.top, lstring.luaS_new(L, str));
     ldo.luaD_inctop(L);
-    L.stack[L.top-1] = new TValue(CT.LUA_TLNGSTR, lstring.luaS_new(L, str));
 };
 
 const luaO_pushvfstring = function(L, fmt, argp) {
@@ -519,11 +522,11 @@ const luaO_pushvfstring = function(L, fmt, argp) {
             case char['d']:
             case char['I']:
                 ldo.luaD_inctop(L);
-                L.stack[L.top-1] = luaO_tostring(L, new TValue(CT.LUA_TNUMINT, argp[a++]));
+                setsvalue2s(L, L.top-1, luaO_tostring(L, new TValue(CT.LUA_TNUMINT, argp[a++])));
                 break;
             case char['f']:
                 ldo.luaD_inctop(L);
-                L.stack[L.top-1] = luaO_tostring(L, new TValue(CT.LUA_TNUMFLT, argp[a++]));
+                setsvalue2s(L, L.top-1, luaO_tostring(L, new TValue(CT.LUA_TNUMFLT, argp[a++])));
                 break;
             case char['p']:
                 let v = argp[a++];
@@ -678,3 +681,4 @@ module.exports.luaO_utf8esc      = luaO_utf8esc;
 module.exports.numarith          = numarith;
 module.exports.setobjs2s         = setobjs2s;
 module.exports.setobj2s          = setobj2s;
+module.exports.setsvalue2s       = setsvalue2s;

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -126,8 +126,18 @@ class TValue {
         this.value = x;
     }
 
+    chgfltvalue(x) {
+        assert(this.type == CT.LUA_TNUMFLT);
+        this.value = x;
+    }
+
     setivalue(x) {
         this.type = CT.LUA_TNUMINT;
+        this.value = x;
+    }
+
+    chgivalue(x) {
+        assert(this.type == CT.LUA_TNUMINT);
         this.value = x;
     }
 

--- a/src/lparser.js
+++ b/src/lparser.js
@@ -1568,7 +1568,7 @@ const luaY_parser = function(L, z, buff, dyd, name, firstchar) {
     L.stack[L.top-1].setclLvalue(cl);
     lexstate.h = ltable.luaH_new(L);  /* create table for scanner */
     ldo.luaD_inctop(L);
-    L.stack[L.top-1] = new TValue(defs.CT.LUA_TTABLE, lexstate.h);
+    L.stack[L.top-1].sethvalue(lexstate.h);
     funcstate.f = cl.p = new Proto(L);
     funcstate.f.source = lstring.luaS_new(L, name);
     lexstate.buff = buff;
@@ -1579,7 +1579,7 @@ const luaY_parser = function(L, z, buff, dyd, name, firstchar) {
     assert(!funcstate.prev && funcstate.nups === 1 && !lexstate.fs);
     /* all scopes should be correctly finished */
     assert(dyd.actvar.n === 0 && dyd.gt.n === 0 && dyd.label.n === 0);
-    L.top--;  /* remove scanner's table */
+    delete L.stack[--L.top];  /* remove scanner's table */
     return cl;  /* closure is on the stack, too */
 };
 

--- a/src/lparser.js
+++ b/src/lparser.js
@@ -1565,7 +1565,7 @@ const luaY_parser = function(L, z, buff, dyd, name, firstchar) {
     let funcstate = new FuncState();
     let cl = lfunc.luaF_newLclosure(L, 1);  /* create main closure */
     ldo.luaD_inctop(L);
-    L.stack[L.top-1] = new TValue(defs.CT.LUA_TLCL, cl);
+    L.stack[L.top-1].setclLvalue(cl);
     lexstate.h = ltable.luaH_new(L);  /* create table for scanner */
     ldo.luaD_inctop(L);
     L.stack[L.top-1] = new TValue(defs.CT.LUA_TTABLE, lexstate.h);

--- a/src/lstate.js
+++ b/src/lstate.js
@@ -109,8 +109,8 @@ const stack_init = function(L1, L) {
     let ci = L1.base_ci;
     ci.next = ci.previous = null;
     ci.callstatus = 0;
-    ci.func = L1.stack[L1.top];
     ci.funcOff = L1.top;
+    ci.func = L1.stack[L1.top];
     L1.stack[L1.top++] = new lobject.TValue(CT.LUA_TNIL, null);
     ci.top = L1.top + defs.LUA_MINSTACK;
     L1.ci = ci;

--- a/src/lstate.js
+++ b/src/lstate.js
@@ -147,7 +147,8 @@ const f_luaopen = function(L) {
 const lua_newthread = function(L) {
     let g = L.l_G;
     let L1 = new lua_State(g);
-    L.stack[L.top++] = new lobject.TValue(CT.LUA_TTHREAD, L1);
+    L.stack[L.top] = new lobject.TValue(CT.LUA_TTHREAD, L1);
+    L.top++;
     assert(L.top <= L.ci.top, "stack overflow");
     L1.hookmask = L.hookmask;
     L1.basehookcount = L.basehookcount;

--- a/src/ltable.js
+++ b/src/ltable.js
@@ -261,8 +261,8 @@ const luaH_next = function(L, table, keyI) {
             } while (entry.key.ttisdeadkey());
         }
     }
-    L.stack[keyI] = new lobject.TValue(entry.key.type, entry.key.value);
-    L.stack[keyI+1] = new lobject.TValue(entry.value.type, entry.value.value);
+    lobject.setobj2s(L, keyI, entry.key);
+    lobject.setobj2s(L, keyI+1, entry.value);
     return true;
 };
 

--- a/src/ltm.js
+++ b/src/ltm.js
@@ -159,11 +159,11 @@ const luaT_trybinTM = function(L, p1, p2, res, event) {
 };
 
 const luaT_callorderTM = function(L, p1, p2, event) {
-    let res = new lobject.TValue(CT.LUA_TNIL, null);
+    let res = new lobject.TValue();
     if (!luaT_callbinTM(L, p1, p2, res, event))
-        return -1;
+        return null;
     else
-        return res.l_isfalse() ? 0 : 1;
+        return !res.l_isfalse();
 };
 
 const fasttm = function(l, et, e) {

--- a/src/ltm.js
+++ b/src/ltm.js
@@ -110,13 +110,13 @@ const luaT_objtypename = function(L, o) {
 const luaT_callTM = function(L, f, p1, p2, p3, hasres) {
     let func = L.top;
 
-    L.stack[L.top] = new lobject.TValue(f.type, f.value); /* push function (assume EXTRA_STACK) */
-    L.stack[L.top + 1] = new lobject.TValue(p1.type, p1.value); /* 1st argument */
-    L.stack[L.top + 2] = new lobject.TValue(p2.type, p2.value); /* 2nd argument */
+    lobject.setobj2s(L, L.top, f); /* push function (assume EXTRA_STACK) */
+    lobject.setobj2s(L, L.top + 1, p1); /* 1st argument */
+    lobject.setobj2s(L, L.top + 2, p2); /* 2nd argument */
     L.top += 3;
 
     if (!hasres)  /* no result? 'p3' is third argument */
-        L.stack[L.top++] = new lobject.TValue(p3.type, p3.value);  /* 3rd argument */
+        lobject.setobj2s(L, L.top++, p3);  /* 3rd argument */
 
     if (L.ci.callstatus & lstate.CIST_LUA)
         ldo.luaD_call(L, func, hasres);

--- a/src/ltm.js
+++ b/src/ltm.js
@@ -108,7 +108,6 @@ const luaT_objtypename = function(L, o) {
 };
 
 const luaT_callTM = function(L, f, p1, p2, p3, hasres) {
-    let result = p3;
     let func = L.top;
 
     L.stack[L.top] = new lobject.TValue(f.type, f.value); /* push function (assume EXTRA_STACK) */
@@ -124,9 +123,8 @@ const luaT_callTM = function(L, f, p1, p2, p3, hasres) {
     else
         ldo.luaD_callnoyield(L, func, hasres);
 
-    if (hasres) {
-        assert(typeof result === "number");
-        L.stack[result] = L.stack[--L.top];
+    if (hasres) {  /* if has result, move it to its place */
+        lobject.setobjs2s(L, p3, --L.top);
     }
 };
 

--- a/src/lundump.js
+++ b/src/lundump.js
@@ -265,8 +265,8 @@ const luaU_undump = function(L, Z, name) {
     let S = new BytecodeParser(L, Z, name);
     S.checkHeader();
     let cl = lfunc.luaF_newLclosure(L, S.readByte());
-    L.stack[L.top].setclLvalue(cl);
     ldo.luaD_inctop(L);
+    L.stack[L.top-1].setclLvalue(cl);
     cl.p = new lfunc.Proto(L);
     S.readFunction(cl.p, null);
     assert(cl.nupvalues === cl.p.upvalues.length);

--- a/src/lundump.js
+++ b/src/lundump.js
@@ -265,8 +265,8 @@ const luaU_undump = function(L, Z, name) {
     let S = new BytecodeParser(L, Z, name);
     S.checkHeader();
     let cl = lfunc.luaF_newLclosure(L, S.readByte());
+    L.stack[L.top].setclLvalue(cl);
     ldo.luaD_inctop(L);
-    L.stack[L.top-1] = new lobject.TValue(defs.CT.LUA_TLCL, cl);
     cl.p = new lfunc.Proto(L);
     S.readFunction(cl.p, null);
     assert(cl.nupvalues === cl.p.upvalues.length);

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -520,7 +520,7 @@ const luaV_execute = function(L) {
 
                     if (0 < step ? idx <= limit : limit <= idx) {
                         ci.l_savedpc += i.sBx;
-                        L.stack[ra].value = idx;
+                        L.stack[ra].chgivalue(idx);  /* update internal index... */
                         L.stack[ra + 3] = new lobject.TValue(CT.LUA_TNUMINT, idx);
                     }
                 } else { /* floating loop */
@@ -530,7 +530,7 @@ const luaV_execute = function(L) {
 
                     if (0 < step ? idx <= limit : limit <= idx) {
                         ci.l_savedpc += i.sBx;
-                        L.stack[ra].value = idx;
+                        L.stack[ra].chgfltvalue(idx);  /* update internal index... */
                         L.stack[ra + 3] = new lobject.TValue(CT.LUA_TNUMFLT, idx);
                     }
                 }

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -34,12 +34,13 @@ const luaV_finishOp = function(L) {
         case OCi.OP_MOD: case OCi.OP_POW:
         case OCi.OP_UNM: case OCi.OP_BNOT: case OCi.OP_LEN:
         case OCi.OP_GETTABUP: case OCi.OP_GETTABLE: case OCi.OP_SELF: {
-            lobject.setobjs2s(L, base + inst.A, --L.top);
+            lobject.setobjs2s(L, base + inst.A, L.top-1);
+            delete L.stack[--L.top];
             break;
         }
         case OCi.OP_LE: case OCi.OP_LT: case OCi.OP_EQ: {
             let res = !L.stack[L.top - 1].l_isfalse();
-            L.top--;
+            delete L.stack[--L.top];
             if (ci.callstatus & lstate.CIST_LEQ) {  /* "<=" using "<" instead? */
                 assert(op === OCi.OP_LE);
                 ci.callstatus ^= lstate.CIST_LEQ;  /* clear mark */
@@ -61,17 +62,39 @@ const luaV_finishOp = function(L) {
             }
             /* move final result to final position */
             lobject.setobjs2s(L, ci.l_base + inst.A, L.top - 1);
-            L.top = ci.top;  /* restore top */
+            /* restore top */
+            if (L.top < ci.top) {
+                while (L.top < ci.top)
+                    L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+            } else {
+                while (L.top > ci.top)
+                    delete L.stack[--L.top];
+            }
             break;
         }
         case OCi.OP_TFORCALL: {
             assert(ci.l_code[ci.l_savedpc].opcode === OCi.OP_TFORLOOP);
-            L.top = ci.top;  /* correct top */
+            /* correct top */
+            if (L.top < ci.top) {
+                while (L.top < ci.top)
+                    L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+            } else {
+                while (L.top > ci.top)
+                    delete L.stack[--L.top];
+            }
             break;
         }
         case OCi.OP_CALL: {
-            if (inst.C - 1 >= 0)  /* nresults >= 0? */
-                L.top = ci.top;  /* adjust results */
+            if (inst.C - 1 >= 0) { /* nresults >= 0? */
+                /* adjust results */
+                if (L.top < ci.top) {
+                    while (L.top < ci.top)
+                        L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+                } else {
+                    while (L.top > ci.top)
+                        delete L.stack[--L.top];
+                }
+            }
             break;
         }
     }
@@ -135,7 +158,7 @@ const luaV_execute = function(L) {
                 break;
             }
             case OCi.OP_LOADBOOL: {
-                L.stack[ra] = new lobject.TValue(CT.LUA_TBOOLEAN, i.B !== 0);
+                L.stack[ra].setbvalue(i.B !== 0);
 
                 if (i.C !== 0)
                     ci.l_savedpc++; /* skip next instruction (if C) */
@@ -144,7 +167,7 @@ const luaV_execute = function(L) {
             }
             case OCi.OP_LOADNIL: {
                 for (let j = 0; j <= i.B; j++)
-                    L.stack[ra + j] = new lobject.TValue(CT.LUA_TNIL, null);
+                    L.stack[ra + j].setnilvalue();
                 break;
             }
             case OCi.OP_GETUPVAL: {
@@ -155,7 +178,7 @@ const luaV_execute = function(L) {
             case OCi.OP_SETUPVAL: {
                 let uv = cl.upvals[i.B];
                 if (uv.isopen()) {
-                    uv.L.stack[uv.v] = L.stack[ra];
+                    uv.L.stack[uv.v].setfrom(L.stack[ra]);
                 } else {
                     uv.value.setfrom(L.stack[ra]);
                 }
@@ -192,7 +215,7 @@ const luaV_execute = function(L) {
                 break;
             }
             case OCi.OP_NEWTABLE: {
-                L.stack[ra] = new lobject.TValue(CT.LUA_TTABLE, ltable.luaH_new(L));
+                L.stack[ra].sethvalue(ltable.luaH_new(L));
                 break;
             }
             case OCi.OP_SELF: {
@@ -210,11 +233,11 @@ const luaV_execute = function(L) {
                 let numberop2 = tonumber(op2);
 
                 if (op1.ttisinteger() && op2.ttisinteger()) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, (op1.value + op2.value)|0);
+                    L.stack[ra].setivalue((op1.value + op2.value)|0);
                 } else if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMFLT, numberop1 + numberop2);
+                    L.stack[ra].setfltvalue(numberop1 + numberop2);
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_ADD);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_ADD);
                 }
                 break;
             }
@@ -225,11 +248,11 @@ const luaV_execute = function(L) {
                 let numberop2 = tonumber(op2);
 
                 if (op1.ttisinteger() && op2.ttisinteger()) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, (op1.value - op2.value)|0);
+                    L.stack[ra].setivalue((op1.value - op2.value)|0);
                 } else if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMFLT, numberop1 - numberop2);
+                    L.stack[ra].setfltvalue(numberop1 - numberop2);
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_SUB);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_SUB);
                 }
                 break;
             }
@@ -240,11 +263,11 @@ const luaV_execute = function(L) {
                 let numberop2 = tonumber(op2);
 
                 if (op1.ttisinteger() && op2.ttisinteger()) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, Math.imul(op1.value, op2.value));
+                    L.stack[ra].setivalue(Math.imul(op1.value, op2.value));
                 } else if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMFLT, numberop1 * numberop2);
+                    L.stack[ra].setfltvalue(numberop1 * numberop2);
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_MUL);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_MUL);
                 }
                 break;
             }
@@ -255,11 +278,11 @@ const luaV_execute = function(L) {
                 let numberop2 = tonumber(op2);
 
                 if (op1.ttisinteger() && op2.ttisinteger()) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, luaV_mod(L, op1.value, op2.value));
+                    L.stack[ra].setivalue(luaV_mod(L, op1.value, op2.value));
                 } else if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMFLT, llimit.luai_nummod(L, numberop1, numberop2));
+                    L.stack[ra].setfltvalue(llimit.luai_nummod(L, numberop1, numberop2));
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_MOD);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_MOD);
                 }
                 break;
             }
@@ -270,9 +293,9 @@ const luaV_execute = function(L) {
                 let numberop2 = tonumber(op2);
 
                 if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMFLT, Math.pow(numberop1, numberop2));
+                    L.stack[ra].setfltvalue(Math.pow(numberop1, numberop2));
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_POW);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_POW);
                 }
                 break;
             }
@@ -283,9 +306,9 @@ const luaV_execute = function(L) {
                 let numberop2 = tonumber(op2);
 
                 if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMFLT, numberop1 / numberop2);
+                    L.stack[ra].setfltvalue(numberop1 / numberop2);
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_DIV);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_DIV);
                 }
                 break;
             }
@@ -296,11 +319,11 @@ const luaV_execute = function(L) {
                 let numberop2 = tonumber(op2);
 
                 if (op1.ttisinteger() && op2.ttisinteger()) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, luaV_div(L, op1.value, op2.value));
+                    L.stack[ra].setivalue(luaV_div(L, op1.value, op2.value));
                 } else if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMFLT, Math.floor(numberop1 / numberop2));
+                    L.stack[ra].setfltvalue(Math.floor(numberop1 / numberop2));
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_IDIV);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_IDIV);
                 }
                 break;
             }
@@ -311,9 +334,9 @@ const luaV_execute = function(L) {
                 let numberop2 = tointeger(op2);
 
                 if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, (numberop1 & numberop2));
+                    L.stack[ra].setivalue(numberop1 & numberop2);
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_BAND);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_BAND);
                 }
                 break;
             }
@@ -324,9 +347,9 @@ const luaV_execute = function(L) {
                 let numberop2 = tointeger(op2);
 
                 if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, (numberop1 | numberop2));
+                    L.stack[ra].setivalue(numberop1 | numberop2);
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_BOR);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_BOR);
                 }
                 break;
             }
@@ -337,9 +360,9 @@ const luaV_execute = function(L) {
                 let numberop2 = tointeger(op2);
 
                 if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, (numberop1 ^ numberop2));
+                    L.stack[ra].setivalue(numberop1 ^ numberop2);
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_BXOR);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_BXOR);
                 }
                 break;
             }
@@ -350,9 +373,9 @@ const luaV_execute = function(L) {
                 let numberop2 = tointeger(op2);
 
                 if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, luaV_shiftl(numberop1, numberop2));
+                    L.stack[ra].setivalue(luaV_shiftl(numberop1, numberop2));
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_SHL);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_SHL);
                 }
                 break;
             }
@@ -363,9 +386,9 @@ const luaV_execute = function(L) {
                 let numberop2 = tointeger(op2);
 
                 if (numberop1 !== false && numberop2 !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, luaV_shiftl(numberop1, -numberop2));
+                    L.stack[ra].setivalue(luaV_shiftl(numberop1, -numberop2));
                 } else {
-                    ltm.luaT_trybinTM(L, op1, op2, ra, ltm.TMS.TM_SHR);
+                    ltm.luaT_trybinTM(L, op1, op2, L.stack[ra], ltm.TMS.TM_SHR);
                 }
                 break;
             }
@@ -374,11 +397,11 @@ const luaV_execute = function(L) {
                 let numberop = tonumber(op);
 
                 if (op.ttisinteger()) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, (-op.value)|0);
+                    L.stack[ra].setivalue((-op.value)|0);
                 } else if (numberop !== false) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMFLT, -numberop);
+                    L.stack[ra].setfltvalue(-numberop);
                 } else {
-                    ltm.luaT_trybinTM(L, op, op, ra, ltm.TMS.TM_UNM);
+                    ltm.luaT_trybinTM(L, op, op, L.stack[ra], ltm.TMS.TM_UNM);
                 }
                 break;
             }
@@ -386,19 +409,19 @@ const luaV_execute = function(L) {
                 let op = L.stack[RB(L, base, i)];
 
                 if (op.ttisinteger()) {
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, ~op.value);
+                    L.stack[ra].setivalue(~op.value);
                 } else {
-                    ltm.luaT_trybinTM(L, op, op, ra, ltm.TMS.TM_BNOT);
+                    ltm.luaT_trybinTM(L, op, op, L.stack[ra], ltm.TMS.TM_BNOT);
                 }
                 break;
             }
             case OCi.OP_NOT: {
                 let op = L.stack[RB(L, base, i)];
-                L.stack[ra] = new lobject.TValue(CT.LUA_TBOOLEAN, op.l_isfalse());
+                L.stack[ra].setbvalue(op.l_isfalse());
                 break;
             }
             case OCi.OP_LEN: {
-                luaV_objlen(L, ra, L.stack[RB(L, base, i)]);
+                luaV_objlen(L, L.stack[ra], L.stack[RB(L, base, i)]);
                 break;
             }
             case OCi.OP_CONCAT: {
@@ -408,7 +431,14 @@ const luaV_execute = function(L) {
                 luaV_concat(L, c - b + 1);
                 let rb = base + b;
                 lobject.setobjs2s(L, ra, rb);
-                L.top = ci.top; /* restore top */
+                /* restore top */
+                if (L.top < ci.top) {
+                    while (L.top < ci.top)
+                        L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+                } else {
+                    while (L.top > ci.top)
+                        delete L.stack[--L.top];
+                }
                 break;
             }
             case OCi.OP_JMP: {
@@ -458,12 +488,26 @@ const luaV_execute = function(L) {
                 let b = i.B;
                 let nresults = i.C - 1;
 
-                if (b !== 0)
-                    L.top = ra+b;
+                if (b !== 0) {
+                    if (L.top < ra+b) {
+                        while (L.top < ra+b)
+                            L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+                    } else {
+                        while (L.top > ra+b)
+                            delete L.stack[--L.top];
+                    }
+                }
 
                 if (ldo.luaD_precall(L, ra, nresults)) {
-                    if (nresults >= 0)
-                        L.top = ci.top;
+                    if (nresults >= 0) {
+                        if (L.top < ci.top) {
+                            while (L.top < ci.top)
+                                L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+                        } else {
+                            while (L.top > ci.top)
+                                delete L.stack[--L.top];
+                        }
+                    }
                 } else {
                     ci = L.ci;
                     continue newframe;
@@ -472,7 +516,16 @@ const luaV_execute = function(L) {
                 break;
             }
             case OCi.OP_TAILCALL: {
-                if (i.B !== 0) L.top = ra + i.B;
+                let b = i.B;
+                if (b !== 0) {
+                    if (L.top < ra+b) {
+                        while (L.top < ra+b)
+                            L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+                    } else {
+                        while (L.top > ra+b)
+                            delete L.stack[--L.top];
+                    }
+                } /* else previous instruction set top */
                 if (ldo.luaD_precall(L, ra, LUA_MULTRET)) { // JS function
                 } else {
                     /* tail call: put called frame (n) in place of caller one (o) */
@@ -485,9 +538,15 @@ const luaV_execute = function(L) {
                     if (cl.p.p.length > 0) lfunc.luaF_close(L, oci.l_base);
                     for (let aux = 0; nfuncOff + aux < lim; aux++)
                         lobject.setobjs2s(L, ofuncOff + aux, nfuncOff + aux);
-                    oci.func = nci.func;
                     oci.l_base = ofuncOff + (nci.l_base - nfuncOff);
-                    oci.top = L.top = ofuncOff + (L.top - nfuncOff);
+                    oci.top = ofuncOff + (L.top - nfuncOff);
+                    if (L.top < nci.top) {
+                        while (L.top < oci.top)
+                            L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+                    } else {
+                        while (L.top > oci.top)
+                            delete L.stack[--L.top];
+                    }
                     oci.l_code = nci.l_code;
                     oci.l_savedpc = nci.l_savedpc;
                     oci.callstatus |= lstate.CIST_TAIL;
@@ -506,10 +565,19 @@ const luaV_execute = function(L) {
 
                 if (ci.callstatus & lstate.CIST_FRESH)
                     return; /* external invocation: return */
-
+                /* invocation via reentry: continue execution */
                 ci = L.ci;
-                if (b) L.top = ci.top;
-
+                if (b) {
+                    if (L.top < ci.top) {
+                        while (L.top < ci.top)
+                            L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+                    } else {
+                        while (L.top > ci.top)
+                            delete L.stack[--L.top];
+                    }
+                }
+                assert(ci.callstatus & lstate.CIST_LUA);
+                assert(ci.l_code[ci.l_savedpc - 1].opcode === OCi.OP_CALL);
                 continue newframe;
             }
             case OCi.OP_FORLOOP: {
@@ -521,7 +589,7 @@ const luaV_execute = function(L) {
                     if (0 < step ? idx <= limit : limit <= idx) {
                         ci.l_savedpc += i.sBx;
                         L.stack[ra].chgivalue(idx);  /* update internal index... */
-                        L.stack[ra + 3] = new lobject.TValue(CT.LUA_TNUMINT, idx);
+                        L.stack[ra + 3].setivalue(idx);
                     }
                 } else { /* floating loop */
                     let step = L.stack[ra + 2].value;
@@ -531,7 +599,7 @@ const luaV_execute = function(L) {
                     if (0 < step ? idx <= limit : limit <= idx) {
                         ci.l_savedpc += i.sBx;
                         L.stack[ra].chgfltvalue(idx);  /* update internal index... */
-                        L.stack[ra + 3] = new lobject.TValue(CT.LUA_TNUMFLT, idx);
+                        L.stack[ra + 3].setfltvalue(idx);
                     }
                 }
                 break;
@@ -550,13 +618,13 @@ const luaV_execute = function(L) {
                     let nlimit, nstep, ninit;
                     if ((nlimit = tonumber(plimit)) === false)
                         ldebug.luaG_runerror(L, defs.to_luastring("'for' limit must be a number", true));
-                    L.stack[ra + 1] = new lobject.TValue(CT.LUA_TNUMFLT, nlimit);
+                    L.stack[ra + 1].setfltvalue(nlimit);
                     if ((nstep = tonumber(pstep)) === false)
                         ldebug.luaG_runerror(L, defs.to_luastring("'for' step must be a number", true));
-                    L.stack[ra + 2] = new lobject.TValue(CT.LUA_TNUMFLT, nstep);
+                    L.stack[ra + 2].setfltvalue(nstep);
                     if ((ninit = tonumber(init)) === false)
                         ldebug.luaG_runerror(L, defs.to_luastring("'for' initial value must be a number", true));
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNUMFLT, ninit - nstep);
+                    L.stack[ra].setfltvalue(ninit - nstep);
                 }
 
                 ci.l_savedpc += i.sBx;
@@ -567,15 +635,28 @@ const luaV_execute = function(L) {
                 lobject.setobjs2s(L, cb+2, ra+2);
                 lobject.setobjs2s(L, cb+1, ra+1);
                 lobject.setobjs2s(L, cb, ra);
-                L.top = cb + 3; /* func. + 2 args (state and index) */
+                /* func. + 2 args (state and index) */
+                if (L.top < cb + 3) {
+                    while (L.top < cb + 3)
+                        L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+                } else {
+                    while (L.top > cb + 3)
+                        delete L.stack[--L.top];
+                }
                 ldo.luaD_call(L, cb, i.C);
+                if (L.top < ci.top) {
+                    while (L.top < ci.top)
+                        L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+                } else {
+                    while (L.top > ci.top)
+                        delete L.stack[--L.top];
+                }
                 /* go straight to OP_TFORLOOP */
-                L.top = ci.top;
                 i = ci.l_code[ci.l_savedpc++];
                 ra = RA(L, base, i);
                 assert(i.opcode === OCi.OP_TFORLOOP);
-                /* fall through */
             }
+            /* fall through */
             case OCi.OP_TFORLOOP: {
                 if (!L.stack[ra + 1].ttisnil()) { /* continue loop? */
                     lobject.setobjs2s(L, ra, ra + 1); /* save control variable */
@@ -601,7 +682,14 @@ const luaV_execute = function(L) {
                     ltable.luaH_setint(h, last--, L.stack[ra + n]);
                 }
 
-                L.top = ci.top; /* correct top (in case of previous open call) */
+                /* correct top (in case of previous open call) */
+                if (L.top < ci.top) {
+                    while (L.top < ci.top)
+                        L.stack[L.top++] = new lobject.TValue(CT.LUA_TNIL, null);
+                } else {
+                    while (L.top > ci.top)
+                        delete L.stack[--L.top];
+                }
                 break;
             }
             case OCi.OP_CLOSURE: {
@@ -620,14 +708,23 @@ const luaV_execute = function(L) {
                 if (b < 0) {
                     b = n;  /* get all var. arguments */
                     ldo.luaD_checkstack(L, n);
-                    L.top = ra + n;
+                    if (L.top >= ra+n) {
+                        while (L.top > ra+n)
+                                delete L.stack[--L.top];
+                    } else {
+                        while (L.top < ra+n) {
+                                L.stack[L.top] = new lobject.TValue();
+                                L.top++;
+                        }
+                    }
+                    assert(L.top == ra + n);
                 }
 
                 for (j = 0; j < b && j < n; j++)
                     lobject.setobjs2s(L, ra + j, base - n + j);
 
                 for (; j < b; j++) /* complete required results with nil */
-                    L.stack[ra + j] = new lobject.TValue(CT.LUA_TNIL, null);
+                    L.stack[ra + j].setnilvalue();
                 break;
             }
             case OCi.OP_EXTRAARG: {
@@ -725,8 +822,9 @@ const luaV_equalobj = function(L, t1, t2) {
     if (tm === null) /* no TM? */
         return 0;
 
-    ltm.luaT_callTM(L, tm, t1, t2, L.top, 1);
-    return L.stack[L.top].l_isfalse() ? 0 : 1;
+    let tv = new lobject.TValue(); /* doesn't use the stack */
+    ltm.luaT_callTM(L, tm, t1, t2, tv, 1);
+    return tv.l_isfalse() ? 0 : 1;
 };
 
 const luaV_rawequalobj = function(t1, t2) {
@@ -890,12 +988,12 @@ const luaV_objlen = function(L, ra, rb) {
             let h = rb.value;
             tm = ltm.fasttm(L, h.metatable, ltm.TMS.TM_LEN);
             if (tm !== null) break; /* metamethod? break switch to call it */
-            L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, ltable.luaH_getn(h)); /* else primitive len */
+            ra.setivalue(ltable.luaH_getn(h)); /* else primitive len */
             return;
         }
         case CT.LUA_TSHRSTR:
         case CT.LUA_TLNGSTR:
-            L.stack[ra] = new lobject.TValue(CT.LUA_TNUMINT, rb.vslen());
+            ra.setivalue(rb.vslen());
             return;
         default: {
             tm = ltm.luaT_gettmbyobj(L, rb, ltm.TMS.TM_LEN);
@@ -989,32 +1087,29 @@ const luaV_concat = function(L, total) {
         let n = 2; /* number of elements handled in this pass (at least 2) */
 
         if (!(L.stack[top-2].ttisstring() || cvt2str(L.stack[top-2])) || !tostring(L, top - 1)) {
-            ltm.luaT_trybinTM(L, L.stack[top-2], L.stack[top-1], top-2, ltm.TMS.TM_CONCAT);
-            delete L.stack[top - 1];
+            ltm.luaT_trybinTM(L, L.stack[top-2], L.stack[top-1], L.stack[top-2], ltm.TMS.TM_CONCAT);
         } else if (isemptystr(L.stack[top-1])) {
             tostring(L, top - 2);
-            delete L.stack[top - 1];
         } else if (isemptystr(L.stack[top-2])) {
             lobject.setobjs2s(L, top - 2, top - 1);
-            delete L.stack[top - 1];
         } else {
             /* at least two non-empty string values; get as many as possible */
             let toconcat = new Array(total);
             toconcat[total-1] = L.stack[top-1].svalue();
-            delete L.stack[top - 1];
             for (n = 1; n < total; n++) {
                 if (!tostring(L, top - n - 1)) {
                         toconcat = toconcat.slice(total-n);
                         break;
                 }
                 toconcat[total-n-1] = L.stack[top - n - 1].svalue();
-                delete L.stack[top - n - 1];
             }
             let ts = lstring.luaS_bless(L, Array.prototype.concat.apply([], toconcat));
             lobject.setsvalue2s(L, top - n, ts);
         }
         total -= n - 1; /* got 'n' strings to create 1 new */
-        L.top -= n - 1; /* popped 'n' strings and pushed one */
+        /* popped 'n' strings and pushed one */
+        for (; L.top > top-(n-1);)
+            delete L.stack[--L.top];
     } while (total > 1); /* repeat until only 1 result left */
 };
 
@@ -1037,14 +1132,14 @@ const gettable = function(L, t, key, ra) {
             } else { /* 't' is a table */
                 tm = ltm.fasttm(L, t.value.metatable, ltm.TMS.TM_INDEX);  /* table's metamethod */
                 if (tm === null) { /* no metamethod? */
-                    L.stack[ra] = new lobject.TValue(CT.LUA_TNIL, null); /* result is nil */
+                    L.stack[ra].setnilvalue(); /* result is nil */
                     return;
                 }
             }
             /* else will try the metamethod */
         }
         if (tm.ttisfunction()) { /* is metamethod a function? */
-            ltm.luaT_callTM(L, tm, t, key, ra, 1); /* call it */
+            ltm.luaT_callTM(L, tm, t, key, L.stack[ra], 1); /* call it */
             return;
         }
         t = tm;  /* else try to access 'tm[key]' */

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -126,13 +126,13 @@ const luaV_execute = function(L) {
             }
             case OCi.OP_LOADK: {
                 let konst = k[i.Bx];
-                L.stack[ra] = new lobject.TValue(konst.type, konst.value);
+                lobject.setobj2s(L, ra, konst);
                 break;
             }
             case OCi.OP_LOADKX: {
                 assert(ci.l_code[ci.l_savedpc].opcode === OCi.OP_EXTRAARG);
                 let konst = k[ci.l_code[ci.l_savedpc++].Ax];
-                L.stack[ra] = new lobject.TValue(konst.type, konst.value);
+                lobject.setobj2s(L, ra, konst);
                 break;
             }
             case OCi.OP_LOADBOOL: {
@@ -150,7 +150,7 @@ const luaV_execute = function(L) {
             }
             case OCi.OP_GETUPVAL: {
                 let o = cl.upvals[i.B].val();
-                L.stack[ra] = new lobject.TValue(o.type, o.value);
+                lobject.setobj2s(L, ra, o);
                 break;
             }
             case OCi.OP_SETUPVAL: {
@@ -1033,7 +1033,7 @@ const gettable = function(L, t, key, ra) {
         } else {
             let slot = ltable.luaH_get(L, t.value, key);
             if (!slot.ttisnil()) {
-                L.stack[ra] = new lobject.TValue(slot.type, slot.value);
+                lobject.setobj2s(L, ra, slot);
                 return;
             } else { /* 't' is a table */
                 tm = ltm.fasttm(L, t.value.metatable, ltm.TMS.TM_INDEX);  /* table's metamethod */

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -752,31 +752,29 @@ const luaV_lessthan = function(L, l, r) {
         return l_strcmp(l.tsvalue(), r.tsvalue()) < 0 ? 1 : 0;
     else {
         let res = ltm.luaT_callorderTM(L, l, r, ltm.TMS.TM_LT);
-        if (res < 0)
+        if (res === null)
             ldebug.luaG_ordererror(L, l, r);
         return res ? 1 : 0;
     }
 };
 
 const luaV_lessequal = function(L, l, r) {
-    let res;
-
     if (l.ttisnumber() && r.ttisnumber())
         return LEnum(l, r) ? 1 : 0;
     else if (l.ttisstring() && r.ttisstring())
         return l_strcmp(l.tsvalue(), r.tsvalue()) <= 0 ? 1 : 0;
     else {
-        res = ltm.luaT_callorderTM(L, l, r, ltm.TMS.TM_LE);
-        if (res >= 0)
+        let res = ltm.luaT_callorderTM(L, l, r, ltm.TMS.TM_LE);
+        if (res !== null)
             return res ? 1 : 0;
     }
     /* try 'lt': */
     L.ci.callstatus |= lstate.CIST_LEQ; /* mark it is doing 'lt' for 'le' */
-    res = ltm.luaT_callorderTM(L, r, l, ltm.TMS.TM_LT);
+    let res = ltm.luaT_callorderTM(L, r, l, ltm.TMS.TM_LT);
     L.ci.callstatus ^= lstate.CIST_LEQ; /* clear mark */
-    if (res < 0)
+    if (res === null)
         ldebug.luaG_ordererror(L, l, r);
-    return res !== 1 ? 1 : 0; /* result is negated */
+    return res ? 0 : 1; /* result is negated */
 };
 
 const luaV_equalobj = function(L, t1, t2) {

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -54,14 +54,13 @@ const luaV_finishOp = function(L) {
             let top = L.top - 1;  /* top when 'luaT_trybinTM' was called */
             let b = inst.B;  /* first element to concatenate */
             let total = top - 1 - (base + b);  /* yet to concatenate */
-            L.stack[top - 2] = L.stack[top];  /* put TM result in proper position */
+            lobject.setobjs2s(L, top - 2, top);  /* put TM result in proper position */
             if (total > 1) {  /* are there elements to concat? */
                 L.top = top - 1;  /* top is one after last element (at top-2) */
                 luaV_concat(L, total);  /* concat them (may yield again) */
             }
-
             /* move final result to final position */
-            L.stack[ci.l_base + inst.A] = L.stack[L.top - 1];
+            lobject.setobjs2s(L, ci.l_base + inst.A, L.top - 1);
             L.top = ci.top;  /* restore top */
             break;
         }

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -943,7 +943,7 @@ const pushclosure = function(L, p, encup, base, ra) {
     let uv = p.upvalues;
     let ncl = new lobject.LClosure(L, nup);
     ncl.p = p;
-    L.stack[ra] = new lobject.TValue(CT.LUA_TLCL, ncl);
+    L.stack[ra].setclLvalue(ncl);
     for (let i = 0; i < nup; i++) {
         if (uv[i].instack)
             ncl.upvals[i] = lfunc.luaF_findupval(L, base + uv[i].idx);

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -967,7 +967,7 @@ const tostring = function(L, i) {
     if (o.ttisstring()) return true;
 
     if (cvt2str(o)) {
-        L.stack[i] = lobject.luaO_tostring(L, o);
+        lobject.setsvalue2s(L, i, lobject.luaO_tostring(L, o));
         return true;
     }
 
@@ -1011,7 +1011,7 @@ const luaV_concat = function(L, total) {
                 delete L.stack[top - n - 1];
             }
             let ts = lstring.luaS_bless(L, Array.prototype.concat.apply([], toconcat));
-            L.stack[top - n] = new lobject.TValue(CT.LUA_TLNGSTR, ts);
+            lobject.setsvalue2s(L, top - n, ts);
         }
         total -= n - 1; /* got 'n' strings to create 1 new */
         L.top -= n - 1; /* popped 'n' strings and pushed one */


### PR DESCRIPTION
For #44

I took the approach to only allocate up to `L.top`, and to deallocate whenever `L.top` changes.
This was the simplest way to audit the code, however it probably creates a lot of garbage for javascript, and probably makes function calls slow.
On the other hand: it means that we would never even need to close over: we'd have that for free.

In future, we'll probably move to allocating in luaD_reallocstack and changing all the `delete` operations to set to `nil`.