### PR TITLE
Give ids to some JS objects

### DIFF
--- a/src/lobject.js
+++ b/src/lobject.js
@@ -576,6 +576,15 @@ const luaO_pushvfstring = function(L, fmt, argp) {
                     v instanceof CClosure ||
                     v instanceof lfunc.UpVal) {
                     pushstr(L, defs.to_luastring("0x"+v.id.toString(16)));
+                } else if (v === null) { /* handle null before checking for typeof == object */
+                    pushstr(L, defs.to_luastring("null"));
+                } else if (typeof v === "function" || typeof v === "object") {
+                    let id = L.l_G.ids.get(v);
+                    if (!id) {
+                        id = L.l_G.id_counter++;
+                        L.l_G.ids.set(v, id);
+                    }
+                    pushstr(L, defs.to_luastring("0x"+id.toString(16)));
                 } else if (typeof v === "number") { /* before check object as null is an object */
                     pushstr(L, defs.to_luastring("Number("+v+")"));
                 } else if (typeof v === "string") { /* before check object as null is an object */

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -585,6 +585,8 @@ const luaO_pushvfstring = function(L, fmt, argp) {
                         L.l_G.ids.set(v, id);
                     }
                     pushstr(L, defs.to_luastring("0x"+id.toString(16)));
+                } else if (v === void 0) {
+                    pushstr(L, defs.to_luastring("undefined"));
                 } else if (typeof v === "number") { /* before check object as null is an object */
                     pushstr(L, defs.to_luastring("Number("+v+")"));
                 } else if (typeof v === "string") { /* before check object as null is an object */

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -576,6 +576,12 @@ const luaO_pushvfstring = function(L, fmt, argp) {
                     v instanceof CClosure ||
                     v instanceof lfunc.UpVal) {
                     pushstr(L, defs.to_luastring("0x"+v.id.toString(16)));
+                } else if (typeof v === "number") { /* before check object as null is an object */
+                    pushstr(L, defs.to_luastring("Number("+v+")"));
+                } else if (typeof v === "string") { /* before check object as null is an object */
+                    pushstr(L, defs.to_luastring("String("+JSON.stringify(v)+")"));
+                } else if (typeof v === "boolean") { /* before check object as null is an object */
+                    pushstr(L, defs.to_luastring(v?"Boolean(true)":"Boolean(false)"));
                 } else {
                     /* user provided object. no id available */
                     pushstr(L, defs.to_luastring("<id NYI>"));

--- a/src/lstate.js
+++ b/src/lstate.js
@@ -74,6 +74,7 @@ class global_State {
 
     constructor() {
         this.id_counter = 0; /* used to give objects unique ids */
+        this.ids = new WeakMap();
 
         this.mainthread = null;
         this.l_registry = new lobject.TValue(CT.LUA_TNIL, null);


### PR DESCRIPTION
Fix most cases that a user would see "<id NYI>" in (e.g.) `tostring` output.
The main user-visible case is JS C functions (not closures).
Others cases are only really seen via lightuserdata.

Not all types are handled yet (mainly `Symbol` is missing.)

  - Null gets special handling, as there is no `Null` constructor
  - Other primitives (booleans, strings, numbers) are emitted as e.g. `Number(2)`
  - Functions and objects are given ids **per-state**. This is notable, as identical C functions will have different ids across different fengari states. This may be unwanted.