### PR TITLE
Misc refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
       "indent": [
         "error",
         4,
-        {"SwitchCase": 1}
+        {
+          "SwitchCase": 1
+        }
       ],
       "linebreak-style": [
         "error",
@@ -65,11 +67,15 @@
       "no-console": 0,
       "no-empty": [
         2,
-        { "allowEmptyCatch": true }
+        {
+          "allowEmptyCatch": true
+        }
       ],
       "no-unused-vars": [
         2,
-        { "args": "none" }
+        {
+          "args": "none"
+        }
       ],
       "semi": [
         "error",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "strftime": "^0.10.0",
     "tmp": "^0.0.33"
   },
+  "sideEffects": false,
   "eslintConfig": {
     "env": {
       "browser": true,

--- a/src/defs.js
+++ b/src/defs.js
@@ -2,115 +2,9 @@
 
 const { LUAI_MAXSTACK } = require('./luaconf.js');
 
-/* mark for precompiled code ('<esc>Lua') */
-const LUA_SIGNATURE           = "\x1bLua";
-
-const LUA_VERSION_MAJOR       = "5";
-const LUA_VERSION_MINOR       = "3";
-const LUA_VERSION_NUM         = 503;
-const LUA_VERSION_RELEASE     = "4";
-
-const LUA_VERSION             = "Lua " + LUA_VERSION_MAJOR + "." + LUA_VERSION_MINOR;
-const LUA_RELEASE             = LUA_VERSION + "." + LUA_VERSION_RELEASE;
-const LUA_COPYRIGHT           = LUA_RELEASE + "  Copyright (C) 1994-2017 Lua.org, PUC-Rio";
-const LUA_AUTHORS             = "R. Ierusalimschy, L. H. de Figueiredo, W. Celes";
-
-const LUA_VERSUFFIX           = "_" + LUA_VERSION_MAJOR + "_" + LUA_VERSION_MINOR;
-
-const LUA_INIT_VAR            = "LUA_INIT";
-const LUA_INITVARVERSION      = LUA_INIT_VAR + LUA_VERSUFFIX;
-
-const thread_status = {
-    LUA_OK:        0,
-    LUA_YIELD:     1,
-    LUA_ERRRUN:    2,
-    LUA_ERRSYNTAX: 3,
-    LUA_ERRMEM:    4,
-    LUA_ERRGCMM:   5,
-    LUA_ERRERR:    6
-};
-
-const constant_types = {
-    LUA_TNONE:          -1,
-    LUA_TNIL:           0,
-    LUA_TBOOLEAN:       1,
-    LUA_TLIGHTUSERDATA: 2,
-    LUA_TNUMBER:        3,
-    LUA_TSTRING:        4,
-    LUA_TTABLE:         5,
-    LUA_TFUNCTION:      6,
-    LUA_TUSERDATA:      7,
-    LUA_TTHREAD:        8,
-    LUA_NUMTAGS:        9
-};
-
-constant_types.LUA_TSHRSTR = constant_types.LUA_TSTRING | (0 << 4);  /* short strings */
-constant_types.LUA_TLNGSTR = constant_types.LUA_TSTRING | (1 << 4);  /* long strings */
-
-constant_types.LUA_TNUMFLT = constant_types.LUA_TNUMBER | (0 << 4);  /* float numbers */
-constant_types.LUA_TNUMINT = constant_types.LUA_TNUMBER | (1 << 4);  /* integer numbers */
-
-constant_types.LUA_TLCL = constant_types.LUA_TFUNCTION | (0 << 4);  /* Lua closure */
-constant_types.LUA_TLCF = constant_types.LUA_TFUNCTION | (1 << 4);  /* light C function */
-constant_types.LUA_TCCL = constant_types.LUA_TFUNCTION | (2 << 4);  /* C closure */
-
 /*
-** Comparison and arithmetic functions
-*/
-
-const LUA_OPADD  = 0;   /* ORDER TM, ORDER OP */
-const LUA_OPSUB  = 1;
-const LUA_OPMUL  = 2;
-const LUA_OPMOD  = 3;
-const LUA_OPPOW  = 4;
-const LUA_OPDIV  = 5;
-const LUA_OPIDIV = 6;
-const LUA_OPBAND = 7;
-const LUA_OPBOR  = 8;
-const LUA_OPBXOR = 9;
-const LUA_OPSHL  = 10;
-const LUA_OPSHR  = 11;
-const LUA_OPUNM  = 12;
-const LUA_OPBNOT = 13;
-
-const LUA_OPEQ = 0;
-const LUA_OPLT = 1;
-const LUA_OPLE = 2;
-
-const LUA_MINSTACK = 20;
-
-const LUA_REGISTRYINDEX = -LUAI_MAXSTACK - 1000;
-
-const lua_upvalueindex = function(i) {
-    return LUA_REGISTRYINDEX - i;
-};
-
-/* predefined values in the registry */
-const LUA_RIDX_MAINTHREAD = 1;
-const LUA_RIDX_GLOBALS    = 2;
-const LUA_RIDX_LAST       = LUA_RIDX_GLOBALS;
-
-class lua_Debug {
-
-    constructor() {
-        this.event = NaN;
-        this.name = null;           /* (n) */
-        this.namewhat = null;       /* (n) 'global', 'local', 'field', 'method' */
-        this.what = null;           /* (S) 'Lua', 'C', 'main', 'tail' */
-        this.source = null;         /* (S) */
-        this.currentline = NaN;     /* (l) */
-        this.linedefined = NaN;     /* (S) */
-        this.lastlinedefined = NaN; /* (S) */
-        this.nups = NaN;            /* (u) number of upvalues */
-        this.nparams = NaN;         /* (u) number of parameters */
-        this.isvararg = NaN;        /* (u) */
-        this.istailcall = NaN;      /* (t) */
-        this.short_src = null;      /* (S) */
-        /* private part */
-        this.i_ci = null;           /* active function */
-    }
-
-}
+ * Fengari specific string conversion functions
+ */
 
 let luastring_from;
 if (typeof Uint8Array.from === "function") {
@@ -298,6 +192,114 @@ const from_userstring = function(str) {
     if (!is_luastring(str)) throw new TypeError("expects an array of bytes");
     return str;
 };
+
+/* mark for precompiled code ('<esc>Lua') */
+const LUA_SIGNATURE           = "\x1bLua";
+
+const LUA_VERSION_MAJOR       = "5";
+const LUA_VERSION_MINOR       = "3";
+const LUA_VERSION_NUM         = 503;
+const LUA_VERSION_RELEASE     = "4";
+
+const LUA_VERSION             = "Lua " + LUA_VERSION_MAJOR + "." + LUA_VERSION_MINOR;
+const LUA_RELEASE             = LUA_VERSION + "." + LUA_VERSION_RELEASE;
+const LUA_COPYRIGHT           = LUA_RELEASE + "  Copyright (C) 1994-2017 Lua.org, PUC-Rio";
+const LUA_AUTHORS             = "R. Ierusalimschy, L. H. de Figueiredo, W. Celes";
+
+const LUA_VERSUFFIX           = "_" + LUA_VERSION_MAJOR + "_" + LUA_VERSION_MINOR;
+
+const LUA_INIT_VAR            = "LUA_INIT";
+const LUA_INITVARVERSION      = LUA_INIT_VAR + LUA_VERSUFFIX;
+
+const thread_status = {
+    LUA_OK:        0,
+    LUA_YIELD:     1,
+    LUA_ERRRUN:    2,
+    LUA_ERRSYNTAX: 3,
+    LUA_ERRMEM:    4,
+    LUA_ERRGCMM:   5,
+    LUA_ERRERR:    6
+};
+
+const constant_types = {
+    LUA_TNONE:          -1,
+    LUA_TNIL:           0,
+    LUA_TBOOLEAN:       1,
+    LUA_TLIGHTUSERDATA: 2,
+    LUA_TNUMBER:        3,
+    LUA_TSTRING:        4,
+    LUA_TTABLE:         5,
+    LUA_TFUNCTION:      6,
+    LUA_TUSERDATA:      7,
+    LUA_TTHREAD:        8,
+    LUA_NUMTAGS:        9
+};
+
+constant_types.LUA_TSHRSTR = constant_types.LUA_TSTRING | (0 << 4);  /* short strings */
+constant_types.LUA_TLNGSTR = constant_types.LUA_TSTRING | (1 << 4);  /* long strings */
+
+constant_types.LUA_TNUMFLT = constant_types.LUA_TNUMBER | (0 << 4);  /* float numbers */
+constant_types.LUA_TNUMINT = constant_types.LUA_TNUMBER | (1 << 4);  /* integer numbers */
+
+constant_types.LUA_TLCL = constant_types.LUA_TFUNCTION | (0 << 4);  /* Lua closure */
+constant_types.LUA_TLCF = constant_types.LUA_TFUNCTION | (1 << 4);  /* light C function */
+constant_types.LUA_TCCL = constant_types.LUA_TFUNCTION | (2 << 4);  /* C closure */
+
+/*
+** Comparison and arithmetic functions
+*/
+
+const LUA_OPADD  = 0;   /* ORDER TM, ORDER OP */
+const LUA_OPSUB  = 1;
+const LUA_OPMUL  = 2;
+const LUA_OPMOD  = 3;
+const LUA_OPPOW  = 4;
+const LUA_OPDIV  = 5;
+const LUA_OPIDIV = 6;
+const LUA_OPBAND = 7;
+const LUA_OPBOR  = 8;
+const LUA_OPBXOR = 9;
+const LUA_OPSHL  = 10;
+const LUA_OPSHR  = 11;
+const LUA_OPUNM  = 12;
+const LUA_OPBNOT = 13;
+
+const LUA_OPEQ = 0;
+const LUA_OPLT = 1;
+const LUA_OPLE = 2;
+
+const LUA_MINSTACK = 20;
+
+const LUA_REGISTRYINDEX = -LUAI_MAXSTACK - 1000;
+
+const lua_upvalueindex = function(i) {
+    return LUA_REGISTRYINDEX - i;
+};
+
+/* predefined values in the registry */
+const LUA_RIDX_MAINTHREAD = 1;
+const LUA_RIDX_GLOBALS    = 2;
+const LUA_RIDX_LAST       = LUA_RIDX_GLOBALS;
+
+class lua_Debug {
+    constructor() {
+        this.event = NaN;
+        this.name = null;           /* (n) */
+        this.namewhat = null;       /* (n) 'global', 'local', 'field', 'method' */
+        this.what = null;           /* (S) 'Lua', 'C', 'main', 'tail' */
+        this.source = null;         /* (S) */
+        this.currentline = NaN;     /* (l) */
+        this.linedefined = NaN;     /* (S) */
+        this.lastlinedefined = NaN; /* (S) */
+        this.nups = NaN;            /* (u) number of upvalues */
+        this.nparams = NaN;         /* (u) number of parameters */
+        this.isvararg = NaN;        /* (u) */
+        this.istailcall = NaN;      /* (t) */
+        this.short_src = null;      /* (S) */
+        /* private part */
+        this.i_ci = null;           /* active function */
+    }
+}
 
 /*
 ** Event codes

--- a/src/defs.js
+++ b/src/defs.js
@@ -2,12 +2,6 @@
 
 const { LUAI_MAXSTACK } = require('./luaconf.js');
 
-// To avoid charCodeAt everywhere
-const char = [];
-for (let i = 0; i < 127; i++)
-    char[String.fromCharCode(i)] = i;
-module.exports.char = char;
-
 /* mark for precompiled code ('<esc>Lua') */
 const LUA_SIGNATURE           = "\x1bLua";
 

--- a/src/defs.js
+++ b/src/defs.js
@@ -358,14 +358,16 @@ if (typeof process === "undefined") {
     const LUA_CDIR = "./lua/" + LUA_VDIR + "/";
     module.exports.LUA_CDIR = LUA_CDIR;
 
-    const LUA_PATH_DEFAULT =
+    const LUA_PATH_DEFAULT = to_luastring(
         LUA_LDIR + "?.lua;" + LUA_LDIR + "?/init.lua;" +
         LUA_CDIR + "?.lua;" + LUA_CDIR + "?/init.lua;" +
-        "./?.lua;./?/init.lua";
+        "./?.lua;./?/init.lua"
+    );
     module.exports.LUA_PATH_DEFAULT = LUA_PATH_DEFAULT;
 
-    const LUA_CPATH_DEFAULT =
-        LUA_CDIR + "?.js;" + LUA_CDIR + "loadall.js;./?.js";
+    const LUA_CPATH_DEFAULT = to_luastring(
+        LUA_CDIR + "?.js;" + LUA_CDIR + "loadall.js;./?.js"
+    );
     module.exports.LUA_CPATH_DEFAULT = LUA_CPATH_DEFAULT;
 } else if (require('os').platform() === 'win32') {
     const LUA_DIRSEP = "\\";
@@ -384,17 +386,19 @@ if (typeof process === "undefined") {
     const LUA_SHRDIR = "!\\..\\share\\lua\\" + LUA_VDIR + "\\";
     module.exports.LUA_SHRDIR = LUA_SHRDIR;
 
-    const LUA_PATH_DEFAULT =
+    const LUA_PATH_DEFAULT = to_luastring(
         LUA_LDIR + "?.lua;" + LUA_LDIR + "?\\init.lua;" +
         LUA_CDIR + "?.lua;" + LUA_CDIR + "?\\init.lua;" +
         LUA_SHRDIR + "?.lua;" + LUA_SHRDIR + "?\\init.lua;" +
-        ".\\?.lua;.\\?\\init.lua";
+        ".\\?.lua;.\\?\\init.lua"
+    );
     module.exports.LUA_PATH_DEFAULT = LUA_PATH_DEFAULT;
 
-    const LUA_CPATH_DEFAULT =
+    const LUA_CPATH_DEFAULT = to_luastring(
         LUA_CDIR + "?.dll;" +
         LUA_CDIR + "..\\lib\\lua\\" + LUA_VDIR + "\\?.dll;" +
-        LUA_CDIR + "loadall.dll;.\\?.dll";
+        LUA_CDIR + "loadall.dll;.\\?.dll"
+    );
     module.exports.LUA_CPATH_DEFAULT = LUA_CPATH_DEFAULT;
 } else {
     const LUA_DIRSEP = "/";
@@ -409,14 +413,16 @@ if (typeof process === "undefined") {
     const LUA_CDIR = LUA_ROOT + "lib/lua/" + LUA_VDIR + "/";
     module.exports.LUA_CDIR = LUA_CDIR;
 
-    const LUA_PATH_DEFAULT =
+    const LUA_PATH_DEFAULT = to_luastring(
         LUA_LDIR + "?.lua;" + LUA_LDIR + "?/init.lua;" +
         LUA_CDIR + "?.lua;" + LUA_CDIR + "?/init.lua;" +
-        "./?.lua;./?/init.lua";
+        "./?.lua;./?/init.lua"
+    );
     module.exports.LUA_PATH_DEFAULT = LUA_PATH_DEFAULT;
 
-    const LUA_CPATH_DEFAULT =
-        LUA_CDIR + "?.so;" + LUA_CDIR + "loadall.so;./?.so";
+    const LUA_CPATH_DEFAULT = to_luastring(
+        LUA_CDIR + "?.so;" + LUA_CDIR + "loadall.so;./?.so"
+    );
     module.exports.LUA_CPATH_DEFAULT = LUA_CPATH_DEFAULT;
 }
 

--- a/src/defs.js
+++ b/src/defs.js
@@ -194,7 +194,7 @@ const from_userstring = function(str) {
 };
 
 /* mark for precompiled code ('<esc>Lua') */
-const LUA_SIGNATURE           = "\x1bLua";
+const LUA_SIGNATURE = to_luastring("\x1bLua");
 
 const LUA_VERSION_MAJOR       = "5";
 const LUA_VERSION_MINOR       = "3";

--- a/src/lapi.js
+++ b/src/lapi.js
@@ -32,10 +32,7 @@ const {
     from_userstring,
     to_luastring,
 } = require('./defs.js');
-const {
-    api_check,
-    lua_assert
-} = require('./llimits.js');
+const { api_check } = require('./llimits.js');
 const ldebug    = require('./ldebug.js');
 const ldo       = require('./ldo.js');
 const { luaU_dump } = require('./ldump.js');
@@ -555,7 +552,7 @@ const aux_upvalue = function(L, fi, n) {
             let name = p.upvalues[n-1].name;
             return {
                 name: name ? name.getstr() : to_luastring("(*no name)", true),
-                val: f.upvals[n-1].v
+                val: f.upvals[n-1]
             };
         }
         default: return null;  /* not a closure */
@@ -930,7 +927,7 @@ const lua_load = function(L, reader, data, chunkname, mode) {
             /* get global table from registry */
             let gt = ltable.luaH_getint(L.l_G.l_registry.value, LUA_RIDX_GLOBALS);
             /* set global table as 1st upvalue of 'f' (may be LUA_ENV) */
-            f.upvals[0].v.setfrom(gt);
+            f.upvals[0].setfrom(gt);
         }
     }
     return status;
@@ -1111,13 +1108,9 @@ const lua_upvalueid = function(L, fidx, n) {
 const lua_upvaluejoin = function(L, fidx1, n1, fidx2, n2) {
     let ref1 = getupvalref(L, fidx1, n1);
     let ref2 = getupvalref(L, fidx2, n2);
-    let up1 = ref1.upval;
     let up2 = ref2.upval;
     let f1 = ref1.closure;
-    lua_assert(up1.refcount > 0);
-    up1.refcount--;
     f1.upvals[ref1.upvalOff] = up2;
-    up2.refcount++;
 };
 
 // This functions are only there for compatibility purposes

--- a/src/lapi.js
+++ b/src/lapi.js
@@ -1079,7 +1079,7 @@ const getupvalref = function(L, fidx, n) {
     let fi = index2addr(L, fidx);
     api_check(L, fi.ttisLclosure(), "Lua function expected");
     let f = fi.value;
-    api_check(L, 1 <= n && n <= f.p.upvalues.length, "invalid upvalue index");
+    api_check(L, n|0 === n && 1 <= n && n <= f.p.upvalues.length, "invalid upvalue index");
     return {
         f: f,
         i: n - 1
@@ -1095,7 +1095,7 @@ const lua_upvalueid = function(L, fidx, n) {
         }
         case LUA_TCCL: {  /* C closure */
             let f = fi.value;
-            api_check(L, 1 <= n && n <= f.nupvalues, "invalid upvalue index");
+            api_check(L, n|0 === n && 1 <= n && n <= f.nupvalues, "invalid upvalue index");
             return f.upvalue[n - 1];
         }
         default: {

--- a/src/lapi.js
+++ b/src/lapi.js
@@ -255,19 +255,19 @@ const lua_pushnil = function(L) {
 };
 
 const lua_pushnumber = function(L, n) {
-    fengari_argcheck(L, typeof n === "number");
+    fengari_argcheck(typeof n === "number");
     L.stack[L.top] = new TValue(LUA_TNUMFLT, n);
     api_incr_top(L);
 };
 
 const lua_pushinteger = function(L, n) {
-    fengari_argcheck(L, typeof n === "number" && (n|0) === n);
+    fengari_argcheck(typeof n === "number" && (n|0) === n);
     L.stack[L.top] = new TValue(LUA_TNUMINT, n);
     api_incr_top(L);
 };
 
 const lua_pushlstring = function(L, s, len) {
-    fengari_argcheck(L, typeof len === "number");
+    fengari_argcheck(typeof len === "number");
     let ts;
     if (len === 0) {
         s = to_luastring("", true);

--- a/src/lapi.js
+++ b/src/lapi.js
@@ -1081,9 +1081,8 @@ const getupvalref = function(L, fidx, n) {
     let f = fi.value;
     api_check(L, 1 <= n && n <= f.p.upvalues.length, "invalid upvalue index");
     return {
-        closure: f,
-        upval: f.upvals[n - 1],
-        upvalOff: n - 1
+        f: f,
+        i: n - 1
     };
 };
 
@@ -1091,7 +1090,8 @@ const lua_upvalueid = function(L, fidx, n) {
     let fi = index2addr(L, fidx);
     switch (fi.ttype()) {
         case LUA_TLCL: {  /* lua closure */
-            return getupvalref(L, fidx, n).upval;
+            let ref = getupvalref(L, fidx, n);
+            return ref.f.upvals[ref.i];
         }
         case LUA_TCCL: {  /* C closure */
             let f = fi.value;
@@ -1108,9 +1108,8 @@ const lua_upvalueid = function(L, fidx, n) {
 const lua_upvaluejoin = function(L, fidx1, n1, fidx2, n2) {
     let ref1 = getupvalref(L, fidx1, n1);
     let ref2 = getupvalref(L, fidx2, n2);
-    let up2 = ref2.upval;
-    let f1 = ref1.closure;
-    f1.upvals[ref1.upvalOff] = up2;
+    let up2 = ref2.f.upvals[ref2.i];
+    ref1.f.upvals[ref1.i] = up2;
 };
 
 // This functions are only there for compatibility purposes

--- a/src/lauxlib.js
+++ b/src/lauxlib.js
@@ -871,7 +871,7 @@ if (typeof process === "undefined") {
         }
         let com = skipcomment(lf);
         /* check for signature first, as we don't want to add line number corrections in binary case */
-        if (com.c === LUA_SIGNATURE.charCodeAt(0) && filename) {  /* binary file? */
+        if (com.c === LUA_SIGNATURE[0] && filename) {  /* binary file? */
             /* no need to re-open in node.js */
         } else if (com.skipped) { /* read initial portion */
             lf.buff[lf.n++] = '\n'.charCodeAt(0);  /* add line to correct line numbers */
@@ -939,7 +939,7 @@ if (typeof process === "undefined") {
         }
         let com = skipcomment(lf);
         /* check for signature first, as we don't want to add line number corrections in binary case */
-        if (com.c === LUA_SIGNATURE.charCodeAt(0) && filename) {  /* binary file? */
+        if (com.c === LUA_SIGNATURE[0] && filename) {  /* binary file? */
             /* no need to re-open in node.js */
         } else if (com.skipped) { /* read initial portion */
             lf.buff[lf.n++] = '\n'.charCodeAt(0);  /* add line to correct line numbers */

--- a/src/lauxlib.js
+++ b/src/lauxlib.js
@@ -148,7 +148,10 @@ const pushglobalfuncname = function(L, ar) {
     lua_getfield(L, LUA_REGISTRYINDEX, LUA_LOADED_TABLE);
     if (findfield(L, top + 1, 2)) {
         let name = lua_tostring(L, -1);
-        if (name[0] === "_".charCodeAt(0) && name[1] === "G".charCodeAt(0) && name[2] === ".".charCodeAt(0)) {  /* name start with '_G.'? */
+        if (name[0] === 95 /* '_'.charCodeAt(0) */ &&
+            name[1] === 71 /* 'G'.charCodeAt(0) */ &&
+            name[2] === 46 /* '.'.charCodeAt(0) */
+        ) {  /* name start with '_G.'? */
             lua_pushstring(L, name.subarray(3));  /* push name without prefix */
             lua_remove(L, -2);  /* remove original name */
         }
@@ -168,9 +171,9 @@ const pushfuncname = function(L, ar) {
     }
     else if (ar.namewhat.length !== 0)  /* is there a name from code? */
         lua_pushfstring(L, to_luastring("%s '%s'"), ar.namewhat, ar.name);  /* use it */
-    else if (ar.what && ar.what[0] === 'm'.charCodeAt(0))  /* main? */
+    else if (ar.what && ar.what[0] === 109 /* 'm'.charCodeAt(0) */)  /* main? */
         lua_pushliteral(L, "main chunk");
-    else if (ar.what && ar.what[0] === 'L'.charCodeAt(0))  /* for Lua functions, use <file:line> */
+    else if (ar.what && ar.what[0] === 76 /* 'L'.charCodeAt(0) */)  /* for Lua functions, use <file:line> */
         lua_pushfstring(L, to_luastring("function <%s:%d>"), ar.short_src, ar.linedefined);
     else  /* nothing left... */
         lua_pushliteral(L, "?");
@@ -792,10 +795,10 @@ const skipBOM = function(lf) {
 */
 const skipcomment = function(lf) {
     let c = skipBOM(lf);
-    if (c === '#'.charCodeAt(0)) {  /* first line is a comment (Unix exec. file)? */
+    if (c === 35 /* '#'.charCodeAt(0) */) {  /* first line is a comment (Unix exec. file)? */
         do {  /* skip first line */
             c = getc(lf);
-        } while (c && c !== '\n'.charCodeAt(0));
+        } while (c && c !== 10 /* '\n'.charCodeAt(0) */);
 
         return {
             skipped: true,
@@ -874,7 +877,7 @@ if (typeof process === "undefined") {
         if (com.c === LUA_SIGNATURE[0] && filename) {  /* binary file? */
             /* no need to re-open in node.js */
         } else if (com.skipped) { /* read initial portion */
-            lf.buff[lf.n++] = '\n'.charCodeAt(0);  /* add line to correct line numbers */
+            lf.buff[lf.n++] = 10 /* '\n'.charCodeAt(0) */;  /* add line to correct line numbers */
         }
         if (com.c !== null)
             lf.buff[lf.n++] = com.c; /* 'c' is the first character of the stream */
@@ -942,7 +945,7 @@ if (typeof process === "undefined") {
         if (com.c === LUA_SIGNATURE[0] && filename) {  /* binary file? */
             /* no need to re-open in node.js */
         } else if (com.skipped) { /* read initial portion */
-            lf.buff[lf.n++] = '\n'.charCodeAt(0);  /* add line to correct line numbers */
+            lf.buff[lf.n++] = 10 /* '\n'.charCodeAt(0) */;  /* add line to correct line numbers */
         }
         if (com.c !== null)
             lf.buff[lf.n++] = com.c; /* 'c' is the first character of the stream */

--- a/src/lbaselib.js
+++ b/src/lbaselib.js
@@ -331,7 +331,7 @@ const luaB_assert = function(L) {
 
 const luaB_select = function(L) {
     let n = lua_gettop(L);
-    if (lua_type(L, 1) === LUA_TSTRING && lua_tostring(L, 1)[0] === "#".charCodeAt(0)) {
+    if (lua_type(L, 1) === LUA_TSTRING && lua_tostring(L, 1)[0] === 35 /* '#'.charCodeAt(0) */) {
         lua_pushinteger(L, n - 1);
         return 1;
     } else {

--- a/src/lbaselib.js
+++ b/src/lbaselib.js
@@ -274,17 +274,9 @@ const b_str2int = function(s, base) {
     }
     let r = /^[\t\v\f \n\r]*([+-]?)0*([0-9A-Za-z]+)[\t\v\f \n\r]*$/.exec(s);
     if (!r) return null;
-    let neg = r[1] === "-";
-    let digits = r[2];
-    let n = 0;
-    for (let si=0; si<digits.length; si++) {
-        let digit = /\d/.test(digits[si])
-            ? (digits.charCodeAt(si) - '0'.charCodeAt(0))
-            : (digits[si].toUpperCase().charCodeAt(0) - 'A'.charCodeAt(0) + 10);
-        if (digit >= base) return null;  /* invalid numeral */
-        n = ((n * base)|0) + digit;
-    }
-    return (neg ? -n : n)|0;
+    let v = parseInt(r[1]+r[2], base);
+    if (isNaN(v)) return null;
+    return v|0;
 };
 
 const luaB_tonumber = function(L) {

--- a/src/ldblib.js
+++ b/src/ldblib.js
@@ -213,29 +213,29 @@ const db_getinfo = function(L) {
     if (!lua_getinfo(L1, options, ar))
         luaL_argerror(L, arg + 2, to_luastring("invalid option", true));
     lua_newtable(L);  /* table to collect results */
-    if (luastring_indexOf(options, 'S'.charCodeAt(0)) > -1) {
+    if (luastring_indexOf(options, 83 /* 'S'.charCodeAt(0) */) > -1) {
         settabss(L, to_luastring("source", true), ar.source);
         settabss(L, to_luastring("short_src", true), ar.short_src);
         settabsi(L, to_luastring("linedefined", true), ar.linedefined);
         settabsi(L, to_luastring("lastlinedefined", true), ar.lastlinedefined);
         settabss(L, to_luastring("what", true), ar.what);
     }
-    if (luastring_indexOf(options, 'l'.charCodeAt(0)) > -1)
+    if (luastring_indexOf(options, 108 /* 'l'.charCodeAt(0) */) > -1)
         settabsi(L, to_luastring("currentline", true), ar.currentline);
-    if (luastring_indexOf(options, 'u'.charCodeAt(0)) > -1) {
+    if (luastring_indexOf(options, 117 /* 'u'.charCodeAt(0) */) > -1) {
         settabsi(L, to_luastring("nups", true), ar.nups);
         settabsi(L, to_luastring("nparams", true), ar.nparams);
         settabsb(L, to_luastring("isvararg", true), ar.isvararg);
     }
-    if (luastring_indexOf(options, 'n'.charCodeAt(0)) > -1) {
+    if (luastring_indexOf(options, 110 /* 'n'.charCodeAt(0) */) > -1) {
         settabss(L, to_luastring("name", true), ar.name);
         settabss(L, to_luastring("namewhat", true), ar.namewhat);
     }
-    if (luastring_indexOf(options, 't'.charCodeAt(0)) > -1)
+    if (luastring_indexOf(options, 116 /* 't'.charCodeAt(0) */) > -1)
         settabsb(L, to_luastring("istailcall", true), ar.istailcall);
-    if (luastring_indexOf(options, 'L'.charCodeAt(0)) > -1)
+    if (luastring_indexOf(options, 76 /* 'L'.charCodeAt(0) */) > -1)
         treatstackoption(L, L1, to_luastring("activelines", true));
-    if (luastring_indexOf(options, 'f'.charCodeAt(0)) > -1)
+    if (luastring_indexOf(options, 102 /* 'f'.charCodeAt(0) */) > -1)
         treatstackoption(L, L1, to_luastring("func", true));
     return 1;  /* return table */
 };
@@ -368,9 +368,9 @@ const hookf = function(L, ar) {
 */
 const makemask = function(smask, count) {
     let mask = 0;
-    if (luastring_indexOf(smask, "c".charCodeAt(0)) > -1) mask |= LUA_MASKCALL;
-    if (luastring_indexOf(smask, "r".charCodeAt(0)) > -1) mask |= LUA_MASKRET;
-    if (luastring_indexOf(smask, "l".charCodeAt(0)) > -1) mask |= LUA_MASKLINE;
+    if (luastring_indexOf(smask, 99 /* 'c'.charCodeAt(0) */) > -1) mask |= LUA_MASKCALL;
+    if (luastring_indexOf(smask, 114 /* 'r'.charCodeAt(0) */) > -1) mask |= LUA_MASKRET;
+    if (luastring_indexOf(smask, 108 /* 'l'.charCodeAt(0) */) > -1) mask |= LUA_MASKLINE;
     if (count > 0) mask |= LUA_MASKCOUNT;
     return mask;
 };
@@ -380,9 +380,9 @@ const makemask = function(smask, count) {
 */
 const unmakemask = function(mask, smask) {
     let i = 0;
-    if (mask & LUA_MASKCALL) smask[i++] = "c".charCodeAt(0);
-    if (mask & LUA_MASKRET) smask[i++] = "r".charCodeAt(0);
-    if (mask & LUA_MASKLINE) smask[i++] = "l".charCodeAt(0);
+    if (mask & LUA_MASKCALL) smask[i++] = 99 /* 'c'.charCodeAt(0) */;
+    if (mask & LUA_MASKRET) smask[i++] = 114 /* 'r'.charCodeAt(0) */;
+    if (mask & LUA_MASKLINE) smask[i++] = 108 /* 'l'.charCodeAt(0) */;
     return smask.subarray(0, i);
 };
 

--- a/src/ldebug.js
+++ b/src/ldebug.js
@@ -537,7 +537,7 @@ const isinstack = function(L, ci, o) {
 const getupvalname = function(L, ci, o) {
     let c = ci.func.value;
     for (let i = 0; i < c.nupvalues; i++) {
-        if (c.upvals[i].v === o) {
+        if (c.upvals[i] === o) {
             return {
                 name: upvalname(c.p, i),
                 funcname: to_luastring('upvalue', true)

--- a/src/ldo.js
+++ b/src/ldo.js
@@ -45,7 +45,7 @@ const ltm      = require('./ltm.js');
 const { LUAI_MAXSTACK } = require('./luaconf.js');
 const lundump  = require('./lundump.js');
 const lvm      = require('./lvm.js');
-const lzio     = require('./lzio.js');
+const { MBuffer } = require('./lzio.js');
 
 const adjust_top = function(L, newtop) {
     if (L.top < newtop) {
@@ -692,7 +692,7 @@ const luaD_callnoyield = function(L, off, nResults) {
 class SParser {
     constructor(z, name, mode) {  /* data to 'f_parser' */
         this.z = z;
-        this.buff = new lzio.MBuffer();  /* dynamic structure used by the scanner */
+        this.buff = new MBuffer();  /* dynamic structure used by the scanner */
         this.dyd = new lparser.Dyndata();  /* dynamic structures used by the parser */
         this.mode = mode;
         this.name = name;

--- a/src/ldo.js
+++ b/src/ldo.js
@@ -710,7 +710,7 @@ const checkmode = function(L, mode, x) {
 const f_parser = function(L, p) {
     let cl;
     let c = p.z.zgetc();  /* read first character */
-    if (c === LUA_SIGNATURE.charCodeAt(0)) {
+    if (c === LUA_SIGNATURE[0]) {
         checkmode(L, p.mode, to_luastring("binary", true));
         cl = lundump.luaU_undump(L, p.z, p.name);
     } else {

--- a/src/ldump.js
+++ b/src/ldump.js
@@ -12,8 +12,7 @@ const {
         LUA_TNUMINT,
         LUA_TSHRSTR
     },
-    luastring_of,
-    to_luastring
+    luastring_of
 } = require('./defs.js');
 
 const LUAC_DATA    = luastring_of(25, 147, 13, 10, 26, 10);
@@ -35,11 +34,6 @@ class DumpState {
 const DumpBlock = function(b, size, D) {
     if (D.status === 0 && size > 0)
         D.status = D.writer(D.L, b, size, D.data);
-};
-
-const DumpLiteral = function(s, D) {
-    s = to_luastring(s);
-    DumpBlock(s, s.length, D);
 };
 
 const DumpByte = function(y, D) {
@@ -172,7 +166,7 @@ const DumpFunction = function(f, psource, D) {
 };
 
 const DumpHeader = function(D) {
-    DumpLiteral(LUA_SIGNATURE, D);
+    DumpBlock(LUA_SIGNATURE, LUA_SIGNATURE.length, D);
     DumpByte(LUAC_VERSION, D);
     DumpByte(LUAC_FORMAT, D);
     DumpBlock(LUAC_DATA, LUAC_DATA.length, D);

--- a/src/lfunc.js
+++ b/src/lfunc.js
@@ -4,7 +4,6 @@ const { constant_types: { LUA_TNIL } } = require('./defs.js');
 const lobject = require('./lobject.js');
 
 class Proto {
-
     constructor(L) {
         this.id = L.l_G.id_counter++;
         this.k = [];              // constants used by the function
@@ -21,12 +20,10 @@ class Proto {
         this.lastlinedefined = 0; // debug information
         this.source = null;       // used for debug information
     }
-
 }
 
 const luaF_newLclosure = function(L, n) {
-    let c = new lobject.LClosure(L, n);
-    return c;
+    return new lobject.LClosure(L, n);
 };
 
 
@@ -47,9 +44,8 @@ const luaF_close = function(L, level) {
 ** fill a closure with new upvalues
 */
 const luaF_initupvals = function(L, cl) {
-    for (let i = 0; i < cl.nupvalues; i++) {
+    for (let i = 0; i < cl.nupvalues; i++)
         cl.upvals[i] = new lobject.TValue(LUA_TNIL, null);
-    }
 };
 
 /*
@@ -66,7 +62,6 @@ const luaF_getlocalname = function(f, local_number, pc) {
     }
     return null;  /* not found */
 };
-
 
 module.exports.MAXUPVAL          = 255;
 module.exports.Proto             = Proto;

--- a/src/llex.js
+++ b/src/llex.js
@@ -30,49 +30,85 @@ const FIRST_RESERVED = 257;
 
 const LUA_ENV = to_luastring("_ENV", true);
 
-const RESERVED = {
-    /* terminal symbols denoted by reserved words */
-    TK_AND:      FIRST_RESERVED,
-    TK_BREAK:    FIRST_RESERVED + 1,
-    TK_DO:       FIRST_RESERVED + 2,
-    TK_ELSE:     FIRST_RESERVED + 3,
-    TK_ELSEIF:   FIRST_RESERVED + 4,
-    TK_END:      FIRST_RESERVED + 5,
-    TK_FALSE:    FIRST_RESERVED + 6,
-    TK_FOR:      FIRST_RESERVED + 7,
-    TK_FUNCTION: FIRST_RESERVED + 8,
-    TK_GOTO:     FIRST_RESERVED + 9,
-    TK_IF:       FIRST_RESERVED + 10,
-    TK_IN:       FIRST_RESERVED + 11,
-    TK_LOCAL:    FIRST_RESERVED + 12,
-    TK_NIL:      FIRST_RESERVED + 13,
-    TK_NOT:      FIRST_RESERVED + 14,
-    TK_OR:       FIRST_RESERVED + 15,
-    TK_REPEAT:   FIRST_RESERVED + 16,
-    TK_RETURN:   FIRST_RESERVED + 17,
-    TK_THEN:     FIRST_RESERVED + 18,
-    TK_TRUE:     FIRST_RESERVED + 19,
-    TK_UNTIL:    FIRST_RESERVED + 20,
-    TK_WHILE:    FIRST_RESERVED + 21,
-    /* other terminal symbols */
-    TK_IDIV:     FIRST_RESERVED + 22,
-    TK_CONCAT:   FIRST_RESERVED + 23,
-    TK_DOTS:     FIRST_RESERVED + 24,
-    TK_EQ:       FIRST_RESERVED + 25,
-    TK_GE:       FIRST_RESERVED + 26,
-    TK_LE:       FIRST_RESERVED + 27,
-    TK_NE:       FIRST_RESERVED + 28,
-    TK_SHL:      FIRST_RESERVED + 29,
-    TK_SHR:      FIRST_RESERVED + 30,
-    TK_DBCOLON:  FIRST_RESERVED + 31,
-    TK_EOS:      FIRST_RESERVED + 32,
-    TK_FLT:      FIRST_RESERVED + 33,
-    TK_INT:      FIRST_RESERVED + 34,
-    TK_NAME:     FIRST_RESERVED + 35,
-    TK_STRING:   FIRST_RESERVED + 36
-};
+/* terminal symbols denoted by reserved words */
+const TK_AND      = FIRST_RESERVED;
+const TK_BREAK    = FIRST_RESERVED + 1;
+const TK_DO       = FIRST_RESERVED + 2;
+const TK_ELSE     = FIRST_RESERVED + 3;
+const TK_ELSEIF   = FIRST_RESERVED + 4;
+const TK_END      = FIRST_RESERVED + 5;
+const TK_FALSE    = FIRST_RESERVED + 6;
+const TK_FOR      = FIRST_RESERVED + 7;
+const TK_FUNCTION = FIRST_RESERVED + 8;
+const TK_GOTO     = FIRST_RESERVED + 9;
+const TK_IF       = FIRST_RESERVED + 10;
+const TK_IN       = FIRST_RESERVED + 11;
+const TK_LOCAL    = FIRST_RESERVED + 12;
+const TK_NIL      = FIRST_RESERVED + 13;
+const TK_NOT      = FIRST_RESERVED + 14;
+const TK_OR       = FIRST_RESERVED + 15;
+const TK_REPEAT   = FIRST_RESERVED + 16;
+const TK_RETURN   = FIRST_RESERVED + 17;
+const TK_THEN     = FIRST_RESERVED + 18;
+const TK_TRUE     = FIRST_RESERVED + 19;
+const TK_UNTIL    = FIRST_RESERVED + 20;
+const TK_WHILE    = FIRST_RESERVED + 21;
+/* other terminal symbols */
+const TK_IDIV     = FIRST_RESERVED + 22;
+const TK_CONCAT   = FIRST_RESERVED + 23;
+const TK_DOTS     = FIRST_RESERVED + 24;
+const TK_EQ       = FIRST_RESERVED + 25;
+const TK_GE       = FIRST_RESERVED + 26;
+const TK_LE       = FIRST_RESERVED + 27;
+const TK_NE       = FIRST_RESERVED + 28;
+const TK_SHL      = FIRST_RESERVED + 29;
+const TK_SHR      = FIRST_RESERVED + 30;
+const TK_DBCOLON  = FIRST_RESERVED + 31;
+const TK_EOS      = FIRST_RESERVED + 32;
+const TK_FLT      = FIRST_RESERVED + 33;
+const TK_INT      = FIRST_RESERVED + 34;
+const TK_NAME     = FIRST_RESERVED + 35;
+const TK_STRING   = FIRST_RESERVED + 36;
 
-const R = RESERVED;
+const RESERVED = {
+    "TK_AND":      TK_AND,
+    "TK_BREAK":    TK_BREAK,
+    "TK_DO":       TK_DO,
+    "TK_ELSE":     TK_ELSE,
+    "TK_ELSEIF":   TK_ELSEIF,
+    "TK_END":      TK_END,
+    "TK_FALSE":    TK_FALSE,
+    "TK_FOR":      TK_FOR,
+    "TK_FUNCTION": TK_FUNCTION,
+    "TK_GOTO":     TK_GOTO,
+    "TK_IF":       TK_IF,
+    "TK_IN":       TK_IN,
+    "TK_LOCAL":    TK_LOCAL,
+    "TK_NIL":      TK_NIL,
+    "TK_NOT":      TK_NOT,
+    "TK_OR":       TK_OR,
+    "TK_REPEAT":   TK_REPEAT,
+    "TK_RETURN":   TK_RETURN,
+    "TK_THEN":     TK_THEN,
+    "TK_TRUE":     TK_TRUE,
+    "TK_UNTIL":    TK_UNTIL,
+    "TK_WHILE":    TK_WHILE,
+    "TK_IDIV":     TK_IDIV,
+    "TK_CONCAT":   TK_CONCAT,
+    "TK_DOTS":     TK_DOTS,
+    "TK_EQ":       TK_EQ,
+    "TK_GE":       TK_GE,
+    "TK_LE":       TK_LE,
+    "TK_NE":       TK_NE,
+    "TK_SHL":      TK_SHL,
+    "TK_SHR":      TK_SHR,
+    "TK_DBCOLON":  TK_DBCOLON,
+    "TK_EOS":      TK_EOS,
+    "TK_FLT":      TK_FLT,
+    "TK_INT":      TK_INT,
+    "TK_NAME":     TK_NAME,
+    "TK_STRING":   TK_STRING
+};
 
 const luaX_tokens = [
     "and", "break", "do", "else", "elseif",
@@ -135,7 +171,7 @@ const luaX_token2str = function(ls, token) {
         return lobject.luaO_pushfstring(ls.L, to_luastring("'%c'", true), token);
     } else {
         let s = luaX_tokens[token - FIRST_RESERVED];
-        if (token < R.TK_EOS)  /* fixed format (symbols and reserved words)? */
+        if (token < TK_EOS)  /* fixed format (symbols and reserved words)? */
             return lobject.luaO_pushfstring(ls.L, to_luastring("'%s'", true), to_luastring(s));
         else  /* names, strings, and numerals */
             return to_luastring(s);
@@ -197,7 +233,7 @@ const luaX_setinput = function(L, ls, z, source, firstchar) {
     ls.L = L;
     ls.current = firstchar;
     ls.lookahead = {
-        token: R.TK_EOS,
+        token: TK_EOS,
         seminfo: new SemInfo()
     };
     ls.z = z;
@@ -253,21 +289,21 @@ const read_numeral = function(ls, seminfo) {
 
     let obj = new lobject.TValue();
     if (lobject.luaO_str2num(luaZ_buffer(ls.buff), obj) === 0)  /* format error? */
-        lexerror(ls, to_luastring("malformed number", true), R.TK_FLT);
+        lexerror(ls, to_luastring("malformed number", true), TK_FLT);
     if (obj.ttisinteger()) {
         seminfo.i = obj.value;
-        return R.TK_INT;
+        return TK_INT;
     } else {
         lua_assert(obj.ttisfloat());
         seminfo.r = obj.value;
-        return R.TK_FLT;
+        return TK_FLT;
     }
 };
 
 const txtToken = function(ls, token) {
     switch (token) {
-        case R.TK_NAME: case R.TK_STRING:
-        case R.TK_FLT: case R.TK_INT:
+        case TK_NAME: case TK_STRING:
+        case TK_FLT: case TK_INT:
             // save(ls, 0);
             return lobject.luaO_pushfstring(ls.L, to_luastring("'%s'", true), luaZ_buffer(ls.buff));
         default:
@@ -316,7 +352,7 @@ const read_long_string = function(ls, seminfo, sep) {
             case EOZ: {  /* error */
                 let what = seminfo ? "string" : "comment";
                 let msg = `unfinished long ${what} (starting at line ${line})`;
-                lexerror(ls, to_luastring(msg), R.TK_EOS);
+                lexerror(ls, to_luastring(msg), TK_EOS);
                 break;
             }
             case 93 /* (']').charCodeAt(0) */: {
@@ -348,7 +384,7 @@ const esccheck = function(ls, c, msg) {
     if (!c) {
         if (ls.current !== EOZ)
             save_and_next(ls);  /* add current to buffer for error message */
-        lexerror(ls, msg, R.TK_STRING);
+        lexerror(ls, msg, TK_STRING);
     }
 };
 
@@ -409,11 +445,11 @@ const read_string = function(ls, del, seminfo) {
     while (ls.current !== del) {
         switch (ls.current) {
             case EOZ:
-                lexerror(ls, to_luastring("unfinished string", true), R.TK_EOS);
+                lexerror(ls, to_luastring("unfinished string", true), TK_EOS);
                 break;
             case 10 /* ('\n').charCodeAt(0) */:
             case 13 /* ('\r').charCodeAt(0) */:
-                lexerror(ls, to_luastring("unfinished string", true), R.TK_STRING);
+                lexerror(ls, to_luastring("unfinished string", true), TK_STRING);
                 break;
             case 92 /* ('\\').charCodeAt(0) */: {  /* escape sequences */
                 save_and_next(ls);  /* keep '\\' for error messages */
@@ -521,54 +557,54 @@ const llex = function(ls, seminfo) {
                 let sep = skip_sep(ls);
                 if (sep >= 0) {
                     read_long_string(ls, seminfo, sep);
-                    return R.TK_STRING;
+                    return TK_STRING;
                 } else if (sep !== -1)  /* '[=...' missing second bracket */
-                    lexerror(ls, to_luastring("invalid long string delimiter", true), R.TK_STRING);
+                    lexerror(ls, to_luastring("invalid long string delimiter", true), TK_STRING);
                 return 91 /* ('[').charCodeAt(0) */;
             }
             case 61 /* ('=').charCodeAt(0) */: {
                 next(ls);
-                if (check_next1(ls, 61 /* ('=').charCodeAt(0) */)) return R.TK_EQ;
+                if (check_next1(ls, 61 /* ('=').charCodeAt(0) */)) return TK_EQ;
                 else return 61 /* ('=').charCodeAt(0) */;
             }
             case 60 /* ('<').charCodeAt(0) */: {
                 next(ls);
-                if (check_next1(ls, 61 /* ('=').charCodeAt(0) */)) return R.TK_LE;
-                else if (check_next1(ls, 60 /* ('<').charCodeAt(0) */)) return R.TK_SHL;
+                if (check_next1(ls, 61 /* ('=').charCodeAt(0) */)) return TK_LE;
+                else if (check_next1(ls, 60 /* ('<').charCodeAt(0) */)) return TK_SHL;
                 else return 60 /* ('<').charCodeAt(0) */;
             }
             case 62 /* ('>').charCodeAt(0) */: {
                 next(ls);
-                if (check_next1(ls, 61 /* ('=').charCodeAt(0) */)) return R.TK_GE;
-                else if (check_next1(ls, 62 /* ('>').charCodeAt(0) */)) return R.TK_SHR;
+                if (check_next1(ls, 61 /* ('=').charCodeAt(0) */)) return TK_GE;
+                else if (check_next1(ls, 62 /* ('>').charCodeAt(0) */)) return TK_SHR;
                 else return 62 /* ('>').charCodeAt(0) */;
             }
             case 47 /* ('/').charCodeAt(0) */: {
                 next(ls);
-                if (check_next1(ls, 47 /* ('/').charCodeAt(0) */)) return R.TK_IDIV;
+                if (check_next1(ls, 47 /* ('/').charCodeAt(0) */)) return TK_IDIV;
                 else return 47 /* ('/').charCodeAt(0) */;
             }
             case 126 /* ('~').charCodeAt(0) */: {
                 next(ls);
-                if (check_next1(ls, 61 /* ('=').charCodeAt(0) */)) return R.TK_NE;
+                if (check_next1(ls, 61 /* ('=').charCodeAt(0) */)) return TK_NE;
                 else return 126 /* ('~').charCodeAt(0) */;
             }
             case 58 /* (':').charCodeAt(0) */: {
                 next(ls);
-                if (check_next1(ls, 58 /* (':').charCodeAt(0) */)) return R.TK_DBCOLON;
+                if (check_next1(ls, 58 /* (':').charCodeAt(0) */)) return TK_DBCOLON;
                 else return 58 /* (':').charCodeAt(0) */;
             }
             case 34 /* ('"').charCodeAt(0) */:
             case 39 /* ('\'').charCodeAt(0) */: {  /* short literal strings */
                 read_string(ls, ls.current, seminfo);
-                return R.TK_STRING;
+                return TK_STRING;
             }
             case 46 /* ('.').charCodeAt(0) */: {  /* '.', '..', '...', or number */
                 save_and_next(ls);
                 if (check_next1(ls, 46 /* ('.').charCodeAt(0) */)) {
                     if (check_next1(ls, 46 /* ('.').charCodeAt(0) */))
-                        return R.TK_DOTS;   /* '...' */
-                    else return R.TK_CONCAT;   /* '..' */
+                        return TK_DOTS;   /* '...' */
+                    else return TK_CONCAT;   /* '..' */
                 }
                 else if (!ljstype.lisdigit(ls.current)) return 46 /* ('.').charCodeAt(0) */;
                 else return read_numeral(ls, seminfo);
@@ -578,7 +614,7 @@ const llex = function(ls, seminfo) {
                 return read_numeral(ls, seminfo);
             }
             case EOZ: {
-                return R.TK_EOS;
+                return TK_EOS;
             }
             default: {
                 if (ljstype.lislalpha(ls.current)) {  /* identifier or reserved word? */
@@ -591,7 +627,7 @@ const llex = function(ls, seminfo) {
                     if (kidx !== void 0 && kidx <= 22)  /* reserved word? */
                         return kidx + FIRST_RESERVED;
                     else
-                        return R.TK_NAME;
+                        return TK_NAME;
                 } else {  /* single-char tokens (+ - / ...) */
                     let c = ls.current;
                     next(ls);
@@ -604,18 +640,18 @@ const llex = function(ls, seminfo) {
 
 const luaX_next = function(ls) {
     ls.lastline = ls.linenumber;
-    if (ls.lookahead.token !== R.TK_EOS) {  /* is there a look-ahead token? */
+    if (ls.lookahead.token !== TK_EOS) {  /* is there a look-ahead token? */
         ls.t.token = ls.lookahead.token;  /* use this one */
         ls.t.seminfo.i = ls.lookahead.seminfo.i;
         ls.t.seminfo.r = ls.lookahead.seminfo.r;
         ls.t.seminfo.ts = ls.lookahead.seminfo.ts; // TODO ?
-        ls.lookahead.token = R.TK_EOS;  /* and discharge it */
+        ls.lookahead.token = TK_EOS;  /* and discharge it */
     } else
         ls.t.token = llex(ls, ls.t.seminfo);  /* read next token */
 };
 
 const luaX_lookahead = function(ls) {
-    lua_assert(ls.lookahead.token === R.TK_EOS);
+    lua_assert(ls.lookahead.token === TK_EOS);
     ls.lookahead.token = llex(ls, ls.lookahead.seminfo);
     return ls.lookahead.token;
 };

--- a/src/llex.js
+++ b/src/llex.js
@@ -118,7 +118,7 @@ const luaX_tokens = [
     "//", "..", "...", "==", ">=", "<=", "~=",
     "<<", ">>", "::", "<eof>",
     "<number>", "<integer>", "<name>", "<string>"
-];
+].map((e, i)=>to_luastring(e));
 
 class SemInfo {
     constructor() {
@@ -172,9 +172,9 @@ const luaX_token2str = function(ls, token) {
     } else {
         let s = luaX_tokens[token - FIRST_RESERVED];
         if (token < TK_EOS)  /* fixed format (symbols and reserved words)? */
-            return lobject.luaO_pushfstring(ls.L, to_luastring("'%s'", true), to_luastring(s));
+            return lobject.luaO_pushfstring(ls.L, to_luastring("'%s'", true), s);
         else  /* names, strings, and numerals */
-            return to_luastring(s);
+            return s;
     }
 };
 
@@ -509,7 +509,7 @@ const read_string = function(ls, del, seminfo) {
 };
 
 const token_to_index = Object.create(null); /* don't want to return true for e.g. 'hasOwnProperty' */
-luaX_tokens.forEach((e, i)=>token_to_index[luaS_hash(to_luastring(e))] = i);
+luaX_tokens.forEach((e, i)=>token_to_index[luaS_hash(e)] = i);
 
 const isreserved = function(w) {
     let kidx = token_to_index[luaS_hashlongstr(w)];

--- a/src/llex.js
+++ b/src/llex.js
@@ -5,7 +5,11 @@ const {
     thread_status: { LUA_ERRSYNTAX },
     to_luastring
 } = require('./defs.js');
-const { lua_assert } = require('./llimits.js');
+const {
+    LUA_MINBUFFER,
+    MAX_INT,
+    lua_assert
+} = require('./llimits.js');
 const ldebug   = require('./ldebug.js');
 const ldo      = require('./ldo.js');
 const ljstype  = require('./ljstype.js');
@@ -17,7 +21,6 @@ const {
     luaS_new
 } = require('./lstring.js');
 const ltable   = require('./ltable.js');
-const llimits  = require('./llimits.js');
 const {
     EOZ,
     luaZ_buffer,
@@ -158,7 +161,7 @@ class LexState {
 const save = function(ls, c) {
     let b = ls.buff;
     if (b.n + 1 > b.buffer.length) {
-        if (b.buffer.length >= llimits.MAX_INT/2)
+        if (b.buffer.length >= MAX_INT/2)
             lexerror(ls, to_luastring("lexical element too long", true), 0);
         let newsize = b.buffer.length*2;
         luaZ_resizebuffer(ls.L, b, newsize);
@@ -221,7 +224,7 @@ const inclinenumber = function(ls) {
     next(ls);  /* skip '\n' or '\r' */
     if (currIsNewline(ls) && ls.current !== old)
         next(ls);  /* skip '\n\r' or '\r\n' */
-    if (++ls.linenumber >= llimits.MAX_INT)
+    if (++ls.linenumber >= MAX_INT)
         lexerror(ls, to_luastring("chunk has too many lines", true), 0);
 };
 
@@ -242,7 +245,7 @@ const luaX_setinput = function(L, ls, z, source, firstchar) {
     ls.lastline = 1;
     ls.source = source;
     ls.envn = luaS_bless(L, LUA_ENV);
-    luaZ_resizebuffer(L, ls.buff, llimits.LUA_MINBUFFER);  /* initialize buffer */
+    luaZ_resizebuffer(L, ls.buff, LUA_MINBUFFER);  /* initialize buffer */
 };
 
 const check_next1 = function(ls, c) {

--- a/src/loadlib.js
+++ b/src/loadlib.js
@@ -288,7 +288,7 @@ const setpath = function(L, fieldname, envname, dft) {
     if (path === undefined)  /* no environment variable? */
         path = env[envname];  /* try unversioned name */
     if (path === undefined || noenv(L))  /* no environment variable? */
-        lua_pushstring(L, to_luastring(dft));  /* use default */
+        lua_pushstring(L, dft);  /* use default */
     else {
         /* replace ";;" by ";AUXMARK;" and then AUXMARK by default path */
         path = luaL_gsub(
@@ -297,7 +297,7 @@ const setpath = function(L, fieldname, envname, dft) {
             to_luastring(LUA_PATH_SEP + LUA_PATH_SEP, true),
             to_luastring(LUA_PATH_SEP + to_jsstring(AUXMARK) + LUA_PATH_SEP, true)
         );
-        luaL_gsub(L, path, AUXMARK, to_luastring(dft));
+        luaL_gsub(L, path, AUXMARK, dft);
         lua_remove(L, -2); /* remove result from 1st 'gsub' */
     }
     lua_setfield(L, -3, fieldname);  /* package[fieldname] = path value */

--- a/src/loadlib.js
+++ b/src/loadlib.js
@@ -87,7 +87,7 @@ const global_env = (function() {
     }
 })();
 
-const CLIBS         = to_luastring("__CLIBS__", true);
+const CLIBS         = to_luastring("__CLIBS__");
 const LUA_PATH_VAR  = "LUA_PATH";
 const LUA_CPATH_VAR = "LUA_CPATH";
 

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -48,7 +48,6 @@ const {
 } = require('./ljstype.js');
 const ldebug  = require('./ldebug.js');
 const ldo     = require('./ldo.js');
-const lfunc   = require('./lfunc.js');
 const lstate  = require('./lstate.js');
 const {
     luaS_bless,
@@ -301,7 +300,7 @@ class LClosure {
 
         this.p = null;
         this.nupvalues = n;
-        this.upvals = new Array(n); /* list of upvalues as UpVals. initialised in luaF_initupvals */
+        this.upvals = new Array(n); /* list of upvalues. initialised in luaF_initupvals */
     }
 
 }
@@ -656,8 +655,7 @@ const luaO_pushvfstring = function(L, fmt, argp) {
                     v instanceof ltable.Table ||
                     v instanceof Udata ||
                     v instanceof LClosure ||
-                    v instanceof CClosure ||
-                    v instanceof lfunc.UpVal) {
+                    v instanceof CClosure) {
                     pushstr(L, to_luastring("0x"+v.id.toString(16)));
                 } else if (v === null) { /* handle null before checking for typeof == object */
                     pushstr(L, to_luastring("null"));

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -15,7 +15,6 @@ const {
     LUA_OPSHR,
     LUA_OPSUB,
     LUA_OPUNM,
-    char,
     constant_types: {
         LUA_NUMTAGS,
         LUA_TBOOLEAN,
@@ -430,7 +429,7 @@ const MAXSIGDIG = 30;
 */
 const lua_strx2number = function(s) {
     let i = 0;
-    let dot = char[lua_getlocaledecpoint()];
+    let dot = lua_getlocaledecpoint();
     let r = 0.0;  /* result (accumulator) */
     let sigdig = 0;  /* number of significant digits */
     let nosigdig = 0;  /* number of non-significant digits */
@@ -597,7 +596,7 @@ const luaO_tostring = function(L, obj) {
         let str = lua_number2str(obj.value);
         // Assume no LUA_COMPAT_FLOATSTRING
         if (/^[-0123456789]+$/.test(str)) {  /* looks like an int? */
-            str += lua_getlocaledecpoint() + '0'; /* adds '.0' to result */
+            str += String.fromCharCode(lua_getlocaledecpoint()) + '0'; /* adds '.0' to result */
         }
         buff = to_luastring(str);
     }

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -657,26 +657,38 @@ const luaO_pushvfstring = function(L, fmt, argp) {
                     v instanceof LClosure ||
                     v instanceof CClosure) {
                     pushstr(L, to_luastring("0x"+v.id.toString(16)));
-                } else if (v === null) { /* handle null before checking for typeof == object */
-                    pushstr(L, to_luastring("null"));
-                } else if (typeof v === "function" || typeof v === "object") {
-                    let id = L.l_G.ids.get(v);
-                    if (!id) {
-                        id = L.l_G.id_counter++;
-                        L.l_G.ids.set(v, id);
+                }
+                switch(typeof v) {
+                    case "undefined":
+                        pushstr(L, to_luastring("undefined"));
+                        break;
+                    case "number":  /* before check object as null is an object */
+                        pushstr(L, to_luastring("Number("+v+")"));
+                        break;
+                    case "string":  /* before check object as null is an object */
+                        pushstr(L, to_luastring("String("+JSON.stringify(v)+")"));
+                        break;
+                    case "boolean":  /* before check object as null is an object */
+                        pushstr(L, to_luastring(v?"Boolean(true)":"Boolean(false)"));
+                        break;
+                    case "object":
+                        if (v === null) { /* null is special */
+                            pushstr(L, to_luastring("null"));
+                            break;
+                        }
+                        /* fall through */
+                    case "function": {
+                        let id = L.l_G.ids.get(v);
+                        if (!id) {
+                            id = L.l_G.id_counter++;
+                            L.l_G.ids.set(v, id);
+                        }
+                        pushstr(L, to_luastring("0x"+id.toString(16)));
+                        break;
                     }
-                    pushstr(L, to_luastring("0x"+id.toString(16)));
-                } else if (v === void 0) {
-                    pushstr(L, to_luastring("undefined"));
-                } else if (typeof v === "number") { /* before check object as null is an object */
-                    pushstr(L, to_luastring("Number("+v+")"));
-                } else if (typeof v === "string") { /* before check object as null is an object */
-                    pushstr(L, to_luastring("String("+JSON.stringify(v)+")"));
-                } else if (typeof v === "boolean") { /* before check object as null is an object */
-                    pushstr(L, to_luastring(v?"Boolean(true)":"Boolean(false)"));
-                } else {
-                    /* user provided object. no id available */
-                    pushstr(L, to_luastring("<id NYI>"));
+                    default:
+                        /* user provided object. no id available */
+                        pushstr(L, to_luastring("<id NYI>"));
                 }
                 break;
             }

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -195,7 +195,7 @@ class TValue {
 
     setnilvalue() {
         this.type = LUA_TNIL;
-        this.value = void 0;
+        this.value = null;
     }
 
     setfvalue(x) {

--- a/src/lobject.js
+++ b/src/lobject.js
@@ -354,7 +354,7 @@ const POS  = to_luastring("\"]");
 const luaO_chunkid = function(source, bufflen) {
     let l = source.length;
     let out;
-    if (source[0] === char['=']) {  /* 'literal' source */
+    if (source[0] === 61 /* ('=').charCodeAt(0) */) {  /* 'literal' source */
         if (l < bufflen) {  /* small enough? */
             out = new Uint8Array(l-1);
             out.set(source.subarray(1));
@@ -362,7 +362,7 @@ const luaO_chunkid = function(source, bufflen) {
             out = new Uint8Array(bufflen);
             out.set(source.subarray(1, bufflen+1));
         }
-    } else if (source[0] === char['@']) {  /* file name */
+    } else if (source[0] === 64 /* ('@').charCodeAt(0) */) {  /* file name */
         if (l <= bufflen) {  /* small enough? */
             out = new Uint8Array(l-1);
             out.set(source.subarray(1));
@@ -374,7 +374,7 @@ const luaO_chunkid = function(source, bufflen) {
         }
     } else {  /* string; format as [string "source"] */
         out = new Uint8Array(bufflen);
-        let nli = luastring_indexOf(source, char['\n']);  /* find first new line (if any) */
+        let nli = luastring_indexOf(source, 10 /* ('\n').charCodeAt(0) */);  /* find first new line (if any) */
         out.set(PRE);  /* add prefix */
         let out_i = PRE.length;
         bufflen -= PRE.length + RETS.length + POS.length;  /* save space for prefix+suffix */
@@ -438,16 +438,16 @@ const lua_strx2number = function(s) {
     let neg;  /* 1 if number is negative */
     let hasdot = false;  /* true after seen a dot */
     while (lisspace(s[i])) i++;  /* skip initial spaces */
-    if ((neg = (s[i] === char['-']))) i++;  /* check signal */
-    else if (s[i] === char['+']) i++;
-    if (!(s[i] === char['0'] && (s[i+1] === char['x'] || s[i+1] === char['X'])))  /* check '0x' */
+    if ((neg = (s[i] === 45 /* ('-').charCodeAt(0) */))) i++;  /* check signal */
+    else if (s[i] === 43 /* ('+').charCodeAt(0) */) i++;
+    if (!(s[i] === 48 /* ('0').charCodeAt(0) */ && (s[i+1] === 120 /* ('x').charCodeAt(0) */ || s[i+1] === 88 /* ('X').charCodeAt(0) */)))  /* check '0x' */
         return null;  /* invalid format (no '0x') */
     for (i += 2; ; i++) {  /* skip '0x' and read numeral */
         if (s[i] === dot) {
             if (hasdot) break;  /* second dot? stop loop */
             else hasdot = true;
         } else if (lisxdigit(s[i])) {
-            if (sigdig === 0 && s[i] === char['0'])  /* non-significant digit (zero)? */
+            if (sigdig === 0 && s[i] === 48 /* ('0').charCodeAt(0) */)  /* non-significant digit (zero)? */
                 nosigdig++;
             else if (++sigdig <= MAXSIGDIG)  /* can read it without overflow? */
                 r = (r * 16) + luaO_hexavalue(s[i]);
@@ -459,16 +459,16 @@ const lua_strx2number = function(s) {
     if (nosigdig + sigdig === 0)  /* no digits? */
         return null;  /* invalid format */
     e *= 4;  /* each digit multiplies/divides value by 2^4 */
-    if (s[i] === char['p'] || s[i] === char['P']) {  /* exponent part? */
+    if (s[i] === 112 /* ('p').charCodeAt(0) */ || s[i] === 80 /* ('P').charCodeAt(0) */) {  /* exponent part? */
         let exp1 = 0;  /* exponent value */
         let neg1;  /* exponent signal */
         i++;  /* skip 'p' */
-        if ((neg1 = (s[i] === char['-']))) i++;  /* signal */
-        else if (s[i] === char['+']) i++;
+        if ((neg1 = (s[i] === 45 /* ('-').charCodeAt(0) */))) i++;  /* signal */
+        else if (s[i] === 43 /* ('+').charCodeAt(0) */) i++;
         if (!lisdigit(s[i]))
             return null;  /* invalid; must have at least one digit */
         while (lisdigit(s[i]))  /* read exponent */
-            exp1 = exp1 * 10 + s[i++] - char['0'];
+            exp1 = exp1 * 10 + s[i++] - 48 /* ('0').charCodeAt(0) */;
         if (neg1) exp1 = -exp1;
         e += exp1;
     }
@@ -501,8 +501,20 @@ const l_str2dloc = function(s, mode) {
     return (result.i === s.length || s[result.i] === 0) ? result : null;  /* OK if no trailing characters */
 };
 
-const SIGILS = [char["."], char["x"], char["X"], char["n"], char["N"]];
-const modes = {[char["."]]: ".", [char["x"]]: "x", [char["X"]]: "x", [char["n"]]: "n", [char["N"]]: "n"};
+const SIGILS = [
+    46  /* (".").charCodeAt(0) */,
+    120 /* ("x").charCodeAt(0) */,
+    88  /* ("X").charCodeAt(0) */,
+    110 /* ("n").charCodeAt(0) */,
+    78  /* ("N").charCodeAt(0) */
+];
+const modes = {
+    [ 46]: ".",
+    [120]: "x",
+    [ 88]: "x",
+    [110]: "n",
+    [ 78]: "n"
+};
 const l_str2d = function(s) {
     let l = s.length;
     let pmode = 0;
@@ -533,9 +545,9 @@ const l_str2int = function(s) {
     let neg;
 
     while (lisspace(s[i])) i++;  /* skip initial spaces */
-    if ((neg = (s[i] === char['-']))) i++;
-    else if (s[i] === char['+']) i++;
-    if (s[i] === char['0'] && (s[i+1] === char['x'] || s[i+1] === char['X'])) {  /* hex? */
+    if ((neg = (s[i] === 45 /* ('-').charCodeAt(0) */))) i++;
+    else if (s[i] === 43 /* ('+').charCodeAt(0) */) i++;
+    if (s[i] === 48 /* ('0').charCodeAt(0) */ && (s[i+1] === 120 /* ('x').charCodeAt(0) */ || s[i+1] === 88 /* ('X').charCodeAt(0) */)) {  /* hex? */
         i += 2;  /* skip '0x' */
 
         for (; lisxdigit(s[i]); i++) {
@@ -544,7 +556,7 @@ const l_str2int = function(s) {
         }
     } else {  /* decimal */
         for (; lisdigit(s[i]); i++) {
-            let d = s[i] - char['0'];
+            let d = s[i] - 48 /* ('0').charCodeAt(0) */;
             if (a >= MAXBY10 && (a > MAXBY10 || d > MAXLASTD + neg))  /* overflow? */
                 return null;  /* do not accept it (as integer) */
             a = (a * 10 + d)|0;
@@ -603,11 +615,11 @@ const luaO_pushvfstring = function(L, fmt, argp) {
     let a = 0;
     let e;
     for (;;) {
-        e = luastring_indexOf(fmt, char['%'], i);
+        e = luastring_indexOf(fmt, 37 /* ('%').charCodeAt(0) */, i);
         if (e == -1) break;
         pushstr(L, fmt.subarray(i, e));
         switch(fmt[e+1]) {
-            case char['s']: {
+            case 115 /* ('s').charCodeAt(0) */: {
                 let s = argp[a++];
                 if (s === null) s = to_luastring("(null)", true);
                 else {
@@ -620,7 +632,7 @@ const luaO_pushvfstring = function(L, fmt, argp) {
                 pushstr(L, s);
                 break;
             }
-            case char['c']: {
+            case 99 /* ('c').charCodeAt(0) */: {
                 let buff = argp[a++];
                 if (lisprint(buff))
                     pushstr(L, luastring_of(buff));
@@ -628,18 +640,18 @@ const luaO_pushvfstring = function(L, fmt, argp) {
                     luaO_pushfstring(L, to_luastring("<\\%d>", true), buff);
                 break;
             }
-            case char['d']:
-            case char['I']:
+            case 100 /* ('d').charCodeAt(0) */:
+            case 73 /* ('I').charCodeAt(0) */:
                 ldo.luaD_inctop(L);
                 L.stack[L.top-1].setivalue(argp[a++]);
                 luaO_tostring(L, L.stack[L.top-1]);
                 break;
-            case char['f']:
+            case 102 /* ('f').charCodeAt(0) */:
                 ldo.luaD_inctop(L);
                 L.stack[L.top-1].setfltvalue(argp[a++]);
                 luaO_tostring(L, L.stack[L.top-1]);
                 break;
-            case char['p']: {
+            case 112 /* ('p').charCodeAt(0) */: {
                 let v = argp[a++];
                 if (v instanceof lstate.lua_State ||
                     v instanceof ltable.Table ||
@@ -671,13 +683,13 @@ const luaO_pushvfstring = function(L, fmt, argp) {
                 }
                 break;
             }
-            case char['U']: {
+            case 85 /* ('U').charCodeAt(0) */: {
                 let buff = new Uint8Array(UTF8BUFFSZ);
                 let l = luaO_utf8esc(buff, argp[a++]);
                 pushstr(L, buff.subarray(UTF8BUFFSZ - l));
                 break;
             }
-            case char['%']:
+            case 37 /* ('%').charCodeAt(0) */:
                 pushstr(L, to_luastring("%", true));
                 break;
             default:

--- a/src/lstate.js
+++ b/src/lstate.js
@@ -18,7 +18,6 @@ const lobject              = require('./lobject.js');
 const ldo                  = require('./ldo.js');
 const lapi                 = require('./lapi.js');
 const ltable               = require('./ltable.js');
-const lfunc                = require('./lfunc.js');
 const ltm                  = require('./ltm.js');
 
 const EXTRA_STACK = 5;
@@ -70,7 +69,6 @@ class lua_State {
         this.basehookcount = 0;
         this.allowhook = 1;
         this.hookcount = this.basehookcount;
-        this.openupval = null;
         this.nny = 1;
         this.status = LUA_OK;
         this.errfunc = 0;
@@ -166,7 +164,6 @@ const lua_newthread = function(L) {
 };
 
 const luaE_freethread = function(L, L1) {
-    lfunc.luaF_close(L1, L1.stack);
     freestack(L1);
 };
 
@@ -183,7 +180,6 @@ const lua_newstate = function() {
 };
 
 const close_state = function(L) {
-    lfunc.luaF_close(L, L.stack);  /* close all upvalues for this thread */
     freestack(L);
 };
 

--- a/src/lstrlib.js
+++ b/src/lstrlib.js
@@ -254,10 +254,10 @@ const addquoted = function(b, s, len) {
 ** Ensures the 'buff' string uses a dot as the radix character.
 */
 const checkdp = function(buff) {
-    if (luastring_indexOf(buff, '.'.charCodeAt(0)) < 0) {  /* no dot? */
+    if (luastring_indexOf(buff, 46 /* ('.').charCodeAt(0) */) < 0) {  /* no dot? */
         let point = lua_getlocaledecpoint();  /* try locale point */
         let ppoint = luastring_indexOf(buff, point);
-        if (ppoint) buff[ppoint] = '.';  /* change it to a dot */
+        if (ppoint) buff[ppoint] = 46 /* ('.').charCodeAt(0) */;  /* change it to a dot */
     }
 };
 

--- a/src/lstrlib.js
+++ b/src/lstrlib.js
@@ -673,15 +673,29 @@ const str_reverse = function(L) {
 
 const str_lower = function(L) {
     let s = luaL_checkstring(L, 1);
-    // TODO: will fail on invalid UTF-8
-    lua_pushstring(L, to_luastring(to_jsstring(s).toLowerCase()));
+    let l = s.length;
+    let r = new Uint8Array(l);
+    for (let i=0; i<l; i++) {
+        let c = s[i];
+        if (isupper(c))
+            c = c | 0x20;
+        r[i] = c;
+    }
+    lua_pushstring(L, r);
     return 1;
 };
 
 const str_upper = function(L) {
     let s = luaL_checkstring(L, 1);
-    // TODO: will fail on invalid UTF-8
-    lua_pushstring(L, to_luastring(to_jsstring(s).toUpperCase()));
+    let l = s.length;
+    let r = new Uint8Array(l);
+    for (let i=0; i<l; i++) {
+        let c = s[i];
+        if (islower(c))
+            c = c & 0xdf;
+        r[i] = c;
+    }
+    lua_pushstring(L, r);
     return 1;
 };
 

--- a/src/lstrlib.js
+++ b/src/lstrlib.js
@@ -255,7 +255,7 @@ const addquoted = function(b, s, len) {
 */
 const checkdp = function(buff) {
     if (luastring_indexOf(buff, '.'.charCodeAt(0)) < 0) {  /* no dot? */
-        let point = lua_getlocaledecpoint().charCodeAt(0);  /* try locale point */
+        let point = lua_getlocaledecpoint();  /* try locale point */
         let ppoint = luastring_indexOf(buff, point);
         if (ppoint) buff[ppoint] = '.';  /* change it to a dot */
     }

--- a/src/lstrlib.js
+++ b/src/lstrlib.js
@@ -433,17 +433,15 @@ class Header {
 /*
 ** options for pack/unpack
 */
-const KOption = {
-    Kint:       0, /* signed integers */
-    Kuint:      1, /* unsigned integers */
-    Kfloat:     2, /* floating-point numbers */
-    Kchar:      3, /* fixed-length strings */
-    Kstring:    4, /* strings with prefixed length */
-    Kzstr:      5, /* zero-terminated strings */
-    Kpadding:   6, /* padding */
-    Kpaddalign: 7, /* padding for alignment */
-    Knop:       8  /* no-op (configuration or spaces) */
-};
+const Kint       = 0; /* signed integers */
+const Kuint      = 1; /* unsigned integers */
+const Kfloat     = 2; /* floating-point numbers */
+const Kchar      = 3; /* fixed-length strings */
+const Kstring    = 4; /* strings with prefixed length */
+const Kzstr      = 5; /* zero-terminated strings */
+const Kpadding   = 6; /* padding */
+const Kpaddalign = 7; /* padding for alignment */
+const Knop       = 8; /* no-op (configuration or spaces) */
 
 const digit = isdigit;
 
@@ -479,31 +477,31 @@ const getoption = function(h, fmt) {
         size: 0  /* default */
     };
     switch (r.opt) {
-        case 98  /*'b'*/: r.size = 1; r.opt = KOption.Kint;   return r; // sizeof(char): 1
-        case 66  /*'B'*/: r.size = 1; r.opt = KOption.Kuint;  return r;
-        case 104 /*'h'*/: r.size = 2; r.opt = KOption.Kint;   return r; // sizeof(short): 2
-        case 72  /*'H'*/: r.size = 2; r.opt = KOption.Kuint;  return r;
-        case 108 /*'l'*/: r.size = 4; r.opt = KOption.Kint;   return r; // sizeof(long): 4
-        case 76  /*'L'*/: r.size = 4; r.opt = KOption.Kuint;  return r;
-        case 106 /*'j'*/: r.size = 4; r.opt = KOption.Kint;   return r; // sizeof(lua_Integer): 4
-        case 74  /*'J'*/: r.size = 4; r.opt = KOption.Kuint;  return r;
-        case 84  /*'T'*/: r.size = 4; r.opt = KOption.Kuint;  return r; // sizeof(size_t): 4
-        case 102 /*'f'*/: r.size = 4; r.opt = KOption.Kfloat; return r; // sizeof(float): 4
-        case 100 /*'d'*/: r.size = 8; r.opt = KOption.Kfloat; return r; // sizeof(double): 8
-        case 110 /*'n'*/: r.size = 8; r.opt = KOption.Kfloat; return r; // sizeof(lua_Number): 8
-        case 105 /*'i'*/: r.size = getnumlimit(h, fmt, 4); r.opt = KOption.Kint;    return r; // sizeof(int): 4
-        case 73  /*'I'*/: r.size = getnumlimit(h, fmt, 4); r.opt = KOption.Kuint;   return r;
-        case 115 /*'s'*/: r.size = getnumlimit(h, fmt, 4); r.opt = KOption.Kstring; return r;
+        case 98  /*'b'*/: r.size = 1; r.opt = Kint;   return r; // sizeof(char): 1
+        case 66  /*'B'*/: r.size = 1; r.opt = Kuint;  return r;
+        case 104 /*'h'*/: r.size = 2; r.opt = Kint;   return r; // sizeof(short): 2
+        case 72  /*'H'*/: r.size = 2; r.opt = Kuint;  return r;
+        case 108 /*'l'*/: r.size = 4; r.opt = Kint;   return r; // sizeof(long): 4
+        case 76  /*'L'*/: r.size = 4; r.opt = Kuint;  return r;
+        case 106 /*'j'*/: r.size = 4; r.opt = Kint;   return r; // sizeof(lua_Integer): 4
+        case 74  /*'J'*/: r.size = 4; r.opt = Kuint;  return r;
+        case 84  /*'T'*/: r.size = 4; r.opt = Kuint;  return r; // sizeof(size_t): 4
+        case 102 /*'f'*/: r.size = 4; r.opt = Kfloat; return r; // sizeof(float): 4
+        case 100 /*'d'*/: r.size = 8; r.opt = Kfloat; return r; // sizeof(double): 8
+        case 110 /*'n'*/: r.size = 8; r.opt = Kfloat; return r; // sizeof(lua_Number): 8
+        case 105 /*'i'*/: r.size = getnumlimit(h, fmt, 4); r.opt = Kint;    return r; // sizeof(int): 4
+        case 73  /*'I'*/: r.size = getnumlimit(h, fmt, 4); r.opt = Kuint;   return r;
+        case 115 /*'s'*/: r.size = getnumlimit(h, fmt, 4); r.opt = Kstring; return r;
         case 99  /*'c'*/: {
             r.size = getnum(fmt, -1);
             if (r.size === -1)
                 luaL_error(h.L, to_luastring("missing size for format option 'c'"));
-            r.opt = KOption.Kchar;
+            r.opt = Kchar;
             return r;
         }
-        case 122 /*'z'*/:             r.opt = KOption.Kzstr;      return r;
-        case 120 /*'x'*/: r.size = 1; r.opt = KOption.Kpadding;   return r;
-        case 88  /*'X'*/:             r.opt = KOption.Kpaddalign; return r;
+        case 122 /*'z'*/:             r.opt = Kzstr;      return r;
+        case 120 /*'x'*/: r.size = 1; r.opt = Kpadding;   return r;
+        case 88  /*'X'*/:             r.opt = Kpaddalign; return r;
         case 32  /*' '*/: break;
         case 60  /*'<'*/: h.islittle = true; break;
         case 62  /*'>'*/: h.islittle = false; break;
@@ -511,7 +509,7 @@ const getoption = function(h, fmt) {
         case 33  /*'!'*/: h.maxalign = getnumlimit(h, fmt, MAXALIGN); break;
         default: luaL_error(h.L, to_luastring("invalid format option '%c'"), r.opt);
     }
-    r.opt = KOption.Knop;
+    r.opt = Knop;
     return r;
 };
 
@@ -535,18 +533,18 @@ const getdetails = function(h, totalsize, fmt) {
     r.size = opt.size;
     r.opt = opt.opt;
     let align = r.size;  /* usually, alignment follows size */
-    if (r.opt === KOption.Kpaddalign) {  /* 'X' gets alignment from following option */
+    if (r.opt === Kpaddalign) {  /* 'X' gets alignment from following option */
         if (fmt.off >= fmt.s.length || fmt.s[fmt.off] === 0)
             luaL_argerror(h.L, 1, to_luastring("invalid next option for option 'X'", true));
         else {
             let o = getoption(h, fmt);
             align = o.size;
             o = o.opt;
-            if (o === KOption.Kchar || align === 0)
+            if (o === Kchar || align === 0)
                 luaL_argerror(h.L, 1, to_luastring("invalid next option for option 'X'", true));
         }
     }
-    if (align <= 1 || r.opt === KOption.Kchar)  /* need no alignment? */
+    if (align <= 1 || r.opt === Kchar)  /* need no alignment? */
         r.ntoalign = 0;
     else {
         if (align > h.maxalign)  /* enforce maximum alignment */
@@ -599,7 +597,7 @@ const str_pack = function(L) {
             luaL_addchar(b, LUAL_PACKPADBYTE);  /* fill alignment */
         arg++;
         switch (opt) {
-            case KOption.Kint: {  /* signed integers */
+            case Kint: {  /* signed integers */
                 let n = luaL_checkinteger(L, arg);
                 if (size < SZINT) {  /* need overflow check? */
                     let lim = 1 << (size * 8) - 1;
@@ -608,14 +606,14 @@ const str_pack = function(L) {
                 packint(b, n, h.islittle, size, n < 0);
                 break;
             }
-            case KOption.Kuint: {  /* unsigned integers */
+            case Kuint: {  /* unsigned integers */
                 let n = luaL_checkinteger(L, arg);
                 if (size < SZINT)
                     luaL_argcheck(L, (n>>>0) < (1 << (size * NB)), arg, to_luastring("unsigned overflow", true));
                 packint(b, n>>>0, h.islittle, size, false);
                 break;
             }
-            case KOption.Kfloat: {  /* floating-point options */
+            case Kfloat: {  /* floating-point options */
                 let buff = luaL_prepbuffsize(b, size);
                 let n = luaL_checknumber(L, arg);  /* get argument */
                 let dv = new DataView(buff.buffer, buff.byteOffset, buff.byteLength);
@@ -624,7 +622,7 @@ const str_pack = function(L) {
                 luaL_addsize(b, size);
                 break;
             }
-            case KOption.Kchar: {  /* fixed-size string */
+            case Kchar: {  /* fixed-size string */
                 let s = luaL_checkstring(L, arg);
                 let len = s.length;
                 luaL_argcheck(L, len <= size, arg, to_luastring("string longer than given size", true));
@@ -633,7 +631,7 @@ const str_pack = function(L) {
                     luaL_addchar(b, LUAL_PACKPADBYTE);
                 break;
             }
-            case KOption.Kstring: {  /* strings with length count */
+            case Kstring: {  /* strings with length count */
                 let s = luaL_checkstring(L, arg);
                 let len = s.length;
                 luaL_argcheck(L,
@@ -644,7 +642,7 @@ const str_pack = function(L) {
                 totalsize += len;
                 break;
             }
-            case KOption.Kzstr: {  /* zero-terminated string */
+            case Kzstr: {  /* zero-terminated string */
                 let s = luaL_checkstring(L, arg);
                 let len = s.length;
                 luaL_argcheck(L, luastring_indexOf(s, 0) < 0, arg, to_luastring("strings contains zeros", true));
@@ -653,8 +651,8 @@ const str_pack = function(L) {
                 totalsize += len + 1;
                 break;
             }
-            case KOption.Kpadding: luaL_addchar(b, LUAL_PACKPADBYTE); /* fall through */
-            case KOption.Kpaddalign: case KOption.Knop:
+            case Kpadding: luaL_addchar(b, LUAL_PACKPADBYTE); /* fall through */
+            case Kpaddalign: case Knop:
                 arg--;  /* undo increment */
                 break;
         }
@@ -750,8 +748,8 @@ const str_packsize = function(L) {
         luaL_argcheck(L, totalsize <= MAXSIZE - size, 1, to_luastring("format result too large", true));
         totalsize += size;
         switch (opt) {
-            case KOption.Kstring:  /* strings with length count */
-            case KOption.Kzstr:    /* zero-terminated string */
+            case Kstring:  /* strings with length count */
+            case Kzstr:    /* zero-terminated string */
                 luaL_argerror(L, 1, to_luastring("variable-length format", true));
                 /* call never return, but to avoid warnings: *//* fall through */
             default:  break;
@@ -825,36 +823,36 @@ const str_unpack = function(L) {
         luaL_checkstack(L, 2, to_luastring("too many results", true));
         n++;
         switch (opt) {
-            case KOption.Kint:
-            case KOption.Kuint: {
-                let res = unpackint(L, data.subarray(pos), h.islittle, size, opt === KOption.Kint);
+            case Kint:
+            case Kuint: {
+                let res = unpackint(L, data.subarray(pos), h.islittle, size, opt === Kint);
                 lua_pushinteger(L, res);
                 break;
             }
-            case KOption.Kfloat: {
+            case Kfloat: {
                 let res = unpacknum(L, data.subarray(pos), h.islittle, size);
                 lua_pushnumber(L, res);
                 break;
             }
-            case KOption.Kchar: {
+            case Kchar: {
                 lua_pushstring(L, data.subarray(pos, pos + size));
                 break;
             }
-            case KOption.Kstring: {
+            case Kstring: {
                 let len = unpackint(L, data.subarray(pos), h.islittle, size, 0);
                 luaL_argcheck(L, pos + len + size <= ld, 2, to_luastring("data string too short", true));
                 lua_pushstring(L, data.subarray(pos + size, pos + size + len));
                 pos += len;  /* skip string */
                 break;
             }
-            case KOption.Kzstr: {
+            case Kzstr: {
                 let e = luastring_indexOf(data, 0, pos);
                 if (e === -1) e = data.length - pos;
                 lua_pushstring(L, data.subarray(pos, e));
                 pos = e + 1;  /* skip string plus final '\0' */
                 break;
             }
-            case KOption.Kpaddalign: case KOption.Kpadding: case KOption.Knop:
+            case Kpaddalign: case Kpadding: case Knop:
                 n--;  /* undo increment */
                 break;
         }

--- a/src/lstrlib.js
+++ b/src/lstrlib.js
@@ -191,10 +191,13 @@ const num2straux = function(x) {
 
 const lua_number2strx = function(L, fmt, x) {
     let buff = num2straux(x);
-    if (fmt[SIZELENMOD] === 'A'.charCodeAt(0)) {
-        for (let i = 0; i < buff.length; i++)
-            buff[i] = String.fromCharCode(buff[i]).toUpperCase().charCodeAt(0);
-    } else if (fmt[SIZELENMOD] !== 'a'.charCodeAt(0))
+    if (fmt[SIZELENMOD] === 65 /* 'A'.charCodeAt(0) */) {
+        for (let i = 0; i < buff.length; i++) {
+            let c = buff[i];
+            if (c >= 97) /* toupper */
+                buff[i] = c & 0xdf;
+        }
+    } else if (fmt[SIZELENMOD] !== 97 /* 'a'.charCodeAt(0) */)
         luaL_error(L, to_luastring("modifiers for format '%%a'/'%%A' not implemented"));
     return buff;
 };

--- a/src/luaconf.js
+++ b/src/luaconf.js
@@ -38,7 +38,7 @@ const LUA_INTEGER_FMT = `%${LUA_INTEGER_FRMLEN}d`;
 const LUA_NUMBER_FMT  = "%.14g";
 
 const lua_getlocaledecpoint = function() {
-    return (1.1).toLocaleString().substring(1, 2);
+    return (1.1).toLocaleString().charCodeAt(1);
 };
 
 const luai_apicheck = function(l, e) {

--- a/src/lundump.js
+++ b/src/lundump.js
@@ -56,7 +56,7 @@ class BytecodeParser {
 
         if (name[0] === 64 /* ('@').charCodeAt(0) */ || name[0] === 61 /* ('=').charCodeAt(0) */)
             this.name = name.subarray(1);
-        else if (name[0] == LUA_SIGNATURE.charCodeAt(0))
+        else if (name[0] == LUA_SIGNATURE[0])
             this.name = to_luastring("binary string", true);
         else
             this.name = name;
@@ -248,7 +248,7 @@ class BytecodeParser {
     }
 
     checkHeader() {
-        this.checkliteral(to_luastring(LUA_SIGNATURE.substring(1)), "not a"); /* 1st char already checked */
+        this.checkliteral(LUA_SIGNATURE.subarray(1), "not a"); /* 1st char already checked */
 
         if (this.readByte() !== 0x53)
             this.error("version mismatch in");

--- a/src/lundump.js
+++ b/src/lundump.js
@@ -2,7 +2,6 @@
 
 const {
     LUA_SIGNATURE,
-    char,
     constant_types: {
         LUA_TBOOLEAN,
         LUA_TLNGSTR,
@@ -41,7 +40,7 @@ const {
     ZIO
 } = require('./lzio.js');
 
-let LUAC_DATA = [0x19, 0x93, char["\r"], char["\n"], 0x1a, char["\n"]];
+let LUAC_DATA = [0x19, 0x93, 13, 10, 0x1a, 10];
 
 class BytecodeParser {
 
@@ -55,7 +54,7 @@ class BytecodeParser {
         lua_assert(Z instanceof ZIO, "BytecodeParser only operates on a ZIO");
         lua_assert(is_luastring(name));
 
-        if (name[0] == char["@"] || name[0] == char["="])
+        if (name[0] === 64 /* ('@').charCodeAt(0) */ || name[0] === 61 /* ('=').charCodeAt(0) */)
             this.name = name.subarray(1);
         else if (name[0] == LUA_SIGNATURE.charCodeAt(0))
             this.name = to_luastring("binary string", true);

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -225,11 +225,11 @@ const luaV_execute = function(L) {
             }
             case OP_GETUPVAL: {
                 let b = i.B;
-                lobject.setobj2s(L, ra, cl.upvals[b].v);
+                lobject.setobj2s(L, ra, cl.upvals[b]);
                 break;
             }
             case OP_GETTABUP: {
-                let upval = cl.upvals[i.B].v;
+                let upval = cl.upvals[i.B];
                 let rc = RKC(L, base, k, i);
                 luaV_gettable(L, upval, rc, ra);
                 break;
@@ -241,7 +241,7 @@ const luaV_execute = function(L) {
                 break;
             }
             case OP_SETTABUP: {
-                let upval = cl.upvals[i.A].v;
+                let upval = cl.upvals[i.A];
                 let rb = RKB(L, base, k, i);
                 let rc = RKC(L, base, k, i);
                 settable(L, upval, rb, rc);
@@ -249,7 +249,7 @@ const luaV_execute = function(L) {
             }
             case OP_SETUPVAL: {
                 let uv = cl.upvals[i.B];
-                uv.v.setfrom(L.stack[ra]);
+                uv.setfrom(L.stack[ra]);
                 break;
             }
             case OP_SETTABLE: {
@@ -973,8 +973,8 @@ const getcached = function(p, encup, stack, base) {
         let uv = p.upvalues;
         let nup = uv.length;
         for (let i = 0; i < nup; i++) {  /* check whether it has right upvalues */
-            let v = uv[i].instack ? stack[base + uv[i].idx] : encup[uv[i].idx].v;
-            if (c.upvals[i].v !== v)
+            let v = uv[i].instack ? stack[base + uv[i].idx] : encup[uv[i].idx];
+            if (c.upvals[i] !== v)
                 return null;  /* wrong upvalue; cannot reuse closure */
         }
     }
@@ -996,7 +996,6 @@ const pushclosure = function(L, p, encup, base, ra) {
             ncl.upvals[i] = lfunc.luaF_findupval(L, base + uv[i].idx);
         else
             ncl.upvals[i] = encup[uv[i].idx];
-        ncl.upvals[i].refcount++;
     }
     p.cache = ncl;  /* save it on cache for reuse */
 };


### PR DESCRIPTION
  - Avoid `.charCodeAt` for code size. I wish I could get webpack to do this at compile time instead...
  - Remove `defs.char`
  - Fix #44 
  - Export some things as lua strings instead of js strings (we should document what is what...)
+ Misc other things

(This was done while on a flight; so its a little bit of everything I could do without any reference material)