### PR TITLE
Expose fengari version

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ Some luaconf options can be chosen at library load time. Fengari looks for `proc
 
 ## Extensions
 
+### `_FENGARI_VERSION_NUM`
+
+A global containing the Fengari version as a number.
+
+
 ### `dv = lua_todataview(L, idx)`
 
 Equivalent to `lua_tolstring` but returns a [`DataView`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) instead of a string.

--- a/src/lbaselib.js
+++ b/src/lbaselib.js
@@ -72,6 +72,7 @@ const {
     luaL_where
 } = require('./lauxlib.js');
 const {
+    FENGARI_VERSION_NUM,
     to_jsstring,
     to_luastring
 } = require("./fengaricore.js");
@@ -496,6 +497,9 @@ const luaopen_base = function(L) {
     /* set global _VERSION */
     lua_pushliteral(L, LUA_VERSION);
     lua_setfield(L, -2, to_luastring("_VERSION"));
+    /* set global _FENGARI_VERSION_NUM */
+    lua_pushinteger(L, FENGARI_VERSION_NUM);
+    lua_setfield(L, -2, to_luastring("_FENGARI_VERSION_NUM"));
     return 1;
 };
 


### PR DESCRIPTION
I wasn't sure whether to do it in the style of Lua's `_VERSION` which is the string `"Lua 5.3"` (e.g. so `_FENGARI_VERSION == "Fengari 0.0.1"`, or as a number, which seems to be more useful.

Closes https://github.com/fengari-lua/fengari-web/issues/13