### PR TITLE
More node 6 fixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+UNRELEASED
+
+  - More node 6 compatibility fixes
+
+
 0.1.1 - 2018-04-03
 
   - Fix node 6 compatibility


### PR DESCRIPTION
fs.writeSync in node 6 doesn't take a Uint8Array
However unexpectedly, other functions such as fs.renameSync are happy with them

Closes https://github.com/fengari-lua/fengari-node-cli/issues/6