### PR TITLE
Remove slot-reserving luaH_set

### DIFF
--- a/src/lapi.js
+++ b/src/lapi.js
@@ -452,12 +452,7 @@ const lua_rawset = function(L, idx) {
     api_check(L, o.ttistable(), "table expected");
     let k = L.stack[L.top - 2];
     let v = L.stack[L.top - 1];
-    if (v.ttisnil()) {
-        ltable.luaH_delete(L, o.value, k);
-    } else {
-        let slot = ltable.luaH_set(L, o.value, k);
-        slot.setfrom(v);
-    }
+    ltable.luaH_setfrom(L, o.value, k, v);
     ltable.invalidateTMcache(o.value);
     delete L.stack[--L.top];
     delete L.stack[--L.top];
@@ -478,12 +473,7 @@ const lua_rawsetp = function(L, idx, p) {
     api_check(L, o.ttistable(), "table expected");
     let k = new TValue(LUA_TLIGHTUSERDATA, p);
     let v = L.stack[L.top - 1];
-    if (v.ttisnil()) {
-        ltable.luaH_delete(L, o.value, k);
-    } else {
-        let slot = ltable.luaH_set(L, o.value, k);
-        slot.setfrom(v);
-    }
+    ltable.luaH_setfrom(L, o.value, k, v);
     delete L.stack[--L.top];
 };
 

--- a/src/lcode.js
+++ b/src/lcode.js
@@ -460,7 +460,7 @@ const freeexps = function(fs, e1, e2) {
 */
 const addk = function(fs, key, v) {
     let f = fs.f;
-    let idx = ltable.luaH_set(fs.L, fs.ls.h, key);  /* index scanner table */
+    let idx = ltable.luaH_get(fs.L, fs.ls.h, key);  /* index scanner table */
     if (idx.ttisinteger()) {  /* is there an index there? */
         let k = idx.value;
         /* correct value? (warning: must distinguish floats from integers!) */
@@ -469,7 +469,7 @@ const addk = function(fs, key, v) {
     }
     /* constant not found; create a new entry */
     let k = fs.nk;
-    idx.setivalue(k);
+    ltable.luaH_setfrom(fs.L, fs.ls.h, key, new lobject.TValue(LUA_TNUMINT, k));
     f.k[k] = v;
     fs.nk++;
     return k;

--- a/src/lvm.js
+++ b/src/lvm.js
@@ -1113,12 +1113,9 @@ const settable = function(L, t, key, val) {
         let tm;
         if (t.ttistable()) {
             let h = t.value; /* save 't' table */
-            let slot = ltable.luaH_set(L, h, key);
+            let slot = ltable.luaH_get(L, h, key);
             if (!slot.ttisnil() || (tm = ltm.fasttm(L, h.metatable, ltm.TMS.TM_NEWINDEX)) === null) {
-                if (val.ttisnil())
-                    ltable.luaH_delete(L, h, key);
-                else
-                    slot.setfrom(val);
+                ltable.luaH_setfrom(L, h, key, val);
                 ltable.invalidateTMcache(h);
                 return;
             }

--- a/test/lua.test.js
+++ b/test/lua.test.js
@@ -53,3 +53,26 @@ test.skip('strings.lua', () => {
         lua.lua_call(L, 0, -1);
     }
 });
+
+
+test('__newindex leaves nils', () => {
+    let L = lauxlib.luaL_newstate();
+    if (!L) throw Error("failed to create lua state");
+
+    let luaCode = `
+        local x = setmetatable({}, {
+          __newindex = function(t,k,v)
+            rawset(t,'_'..k,v)
+          end
+        })
+        x.test = 4
+        for k,v in pairs(x) do
+          assert(k ~= "test", "found phantom key")
+        end
+    `;
+    {
+        lualib.luaL_openlibs(L);
+        expect(lauxlib.luaL_loadstring(L, to_luastring(luaCode))).toBe(lua.LUA_OK);
+        lua.lua_call(L, 0, -1);
+    }
+});


### PR DESCRIPTION
Reserving a slot results in `nil` being left in the table
if the slot isn't used.

This resulted in __newindex creating `nil`s.

This commit replaces the C-derived luaH_set interface with
a new function luaH_setfrom. It also removes the luaH_delete
function in lieu of performing deletions within luaH_set*

Fixes #138