### PR TITLE
Invert the behaviour of luai_apicheck (and adjust api_check accordingly)

### DIFF
--- a/src/llimits.js
+++ b/src/llimits.js
@@ -7,10 +7,10 @@ const lua_assert = function(c) {
 };
 module.exports.lua_assert = lua_assert;
 
-module.exports.luai_apicheck = luai_apicheck || function(l, e) { return lua_assert(e); };
+module.exports.luai_apicheck = luai_apicheck || function(l, e) { return lua_assert(!e); };
 
 const api_check = function(l, e, msg) {
-    return luai_apicheck(l, e && msg);
+    return luai_apicheck(l, !e && msg);
 };
 module.exports.api_check = api_check;
 

--- a/src/luaconf.js
+++ b/src/luaconf.js
@@ -173,7 +173,7 @@ const lua_getlocaledecpoint = function() {
 };
 
 const luai_apicheck = function(l, e) {
-    if (!e) throw Error(e);
+    if (e) throw Error(e);
 };
 
 /*

--- a/test/test-suite/errors.test.js
+++ b/test/test-suite/errors.test.js
@@ -893,3 +893,18 @@ test("[test-suite] errors: local variables limit", () => {
         throw new SyntaxError(lua.lua_tojsstring(L, -1));
     lua.lua_call(L, 0, 0);
 });
+
+test("[test-suite] errors: api_check messages", () => {
+    let L = lauxlib.luaL_newstate();
+    if (!L) throw Error("failed to create lua state");
+
+    try {
+        // Intentionally generate a stack underflow.
+        lua.lua_pop(L, 255);
+        // We should never get here.
+        throw new Error("api_check(stack underflow) didn't fire");
+    } catch (e) {
+        if (e.message !== "invalid new top")
+            throw new Error("api_check threw the wrong message: " + e.message);
+    }
+});


### PR DESCRIPTION
This fixes an issue where if an assert fails, rather than the error message,
the string "false" is thrown instead; the root cause of this is that in C,
the error message was automatically generated from the complete expression
passed to assert (condition && message) even if (condition) was false (and
thus fired the assert). In JS, the message has to be passed separately, and
instead (condition && message) was evaluating to false and then producing
`throw new Error(false)`.

Tested: unit tests