### PR TITLE
src/: remove luai_apicheck

### DIFF
--- a/src/llimits.js
+++ b/src/llimits.js
@@ -1,16 +1,12 @@
 "use strict";
 
-const { luai_apicheck } = require("./luaconf.js");
-
 const lua_assert = function(c) {
     if (!c) throw Error("assertion failed");
 };
 module.exports.lua_assert = lua_assert;
 
-module.exports.luai_apicheck = luai_apicheck || function(l, e) { return lua_assert(e); };
-
 const api_check = function(l, e, msg) {
-    return luai_apicheck(l, e && msg);
+    if (!e) throw Error(msg);
 };
 module.exports.api_check = api_check;
 

--- a/src/luaconf.js
+++ b/src/luaconf.js
@@ -172,10 +172,6 @@ const lua_getlocaledecpoint = function() {
     return 46 /* '.'.charCodeAt(0) */;
 };
 
-const luai_apicheck = function(l, e) {
-    if (!e) throw Error(e);
-};
-
 /*
 @@ LUAL_BUFFERSIZE is the buffer size used by the lauxlib buffer system.
 */
@@ -220,4 +216,3 @@ module.exports.lua_getlocaledecpoint  = lua_getlocaledecpoint;
 module.exports.lua_integer2str        = lua_integer2str;
 module.exports.lua_number2str         = lua_number2str;
 module.exports.lua_numbertointeger    = lua_numbertointeger;
-module.exports.luai_apicheck          = luai_apicheck;


### PR DESCRIPTION
The definition was inverted and the correct error message wasn't thrown.
As we can't match the C-style definition from Lua and that it wasn't
very configurable, it makes sense to remove it.

Replaces #158