### PR TITLE
Don't load Node-specific code when bundled via Webpack

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 UNRELEASED
 
+  - Fix Fengari loading Node-specific code when bundled for the web with Webpack
   - Add os.setlocale that only understands the C locale
   - Fix incorrect length for certain tables
   - Remove luai_apicheck

--- a/src/isnode.js
+++ b/src/isnode.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const isBrowser = ((typeof process === "undefined") || process.browser);
+const isNode = !isBrowser;
+
+module.exports.isBrowser = isBrowser;
+module.exports.isNode    = isNode;

--- a/src/lauxlib.js
+++ b/src/lauxlib.js
@@ -84,6 +84,9 @@ const {
     to_luastring,
     to_uristring
 } = require("./fengaricore.js");
+const {
+    isBrowser
+} = require("./isnode.js");
 
 /* extra error code for 'luaL_loadfilex' */
 const LUA_ERRFILE = LUA_ERRERR+1;
@@ -820,7 +823,7 @@ const skipcomment = function(lf) {
 
 let luaL_loadfilex;
 
-if (typeof process === "undefined") {
+if (isBrowser) {
     class LoadF {
         constructor() {
             this.n = NaN;  /* number of pre-read characters */
@@ -989,7 +992,7 @@ const luaL_dofile = function(L, filename) {
 const lua_writestringerror = function() {
     for (let i=0; i<arguments.length; i++) {
         let a = arguments[i];
-        if (typeof process === "undefined") {
+        if (isBrowser) {
             /* split along new lines for separate console.error invocations */
             do {
                 /* regexp uses [\d\D] to work around matching new lines

--- a/src/lbaselib.js
+++ b/src/lbaselib.js
@@ -75,10 +75,13 @@ const {
     to_jsstring,
     to_luastring
 } = require("./fengaricore.js");
+const {
+    isBrowser
+} = require("./isnode.js");
 
 let lua_writestring;
 let lua_writeline;
-if (typeof process === "undefined") {
+if (isBrowser) {
     if (typeof TextDecoder === "function") { /* Older browsers don't have TextDecoder */
         let buff = "";
         let decoder = new TextDecoder("utf-8");

--- a/src/ldblib.js
+++ b/src/ldblib.js
@@ -78,6 +78,9 @@ const {
     luastring_indexOf,
     to_luastring
 } = require("./fengaricore.js");
+const {
+    isNode
+} = require("./isnode.js");
 
 /*
 ** If L1 != L, L1 can be in any state, and therefore there are no
@@ -469,7 +472,7 @@ const dblib = {
 };
 
 let getinput;
-if (typeof process !== "undefined") { // Only with Node
+if (isNode) { // Only with Node
     const readlineSync = require('readline-sync');
     readlineSync.setDefaultOptions({
         prompt: 'lua_debug> '

--- a/src/linit.js
+++ b/src/linit.js
@@ -3,6 +3,7 @@
 const { lua_pop } = require('./lua.js');
 const { luaL_requiref } = require('./lauxlib.js');
 const { to_luastring } = require("./fengaricore.js");
+const { isNode } = require("./isnode.js");
 
 const loadedlibs = {};
 
@@ -36,7 +37,7 @@ loadedlibs[lualib.LUA_STRLIBNAME] = luaopen_string;
 loadedlibs[lualib.LUA_MATHLIBNAME] = luaopen_math;
 loadedlibs[lualib.LUA_UTF8LIBNAME] = luaopen_utf8;
 loadedlibs[lualib.LUA_DBLIBNAME] = luaopen_debug;
-if (typeof process !== "undefined")
+if (isNode)
     loadedlibs[lualib.LUA_IOLIBNAME] = require('./liolib.js').luaopen_io;
 
 /* Extension: fengari library */

--- a/src/loadlib.js
+++ b/src/loadlib.js
@@ -71,9 +71,13 @@ const {
     to_uristring
 } = require("./fengaricore.js");
 const fengari  = require('./fengari.js');
+const {
+    isBrowser,
+    isNode
+} = require("./isnode.js");
 
 const global_env = (function() {
-    if (typeof process !== "undefined") {
+    if (isNode) {
         /* node */
         return global;
     } else if (typeof window !== "undefined") {
@@ -120,7 +124,7 @@ const AUXMARK = to_luastring("\x01");
 ** error string in the stack.
 */
 let lsys_load;
-if (typeof process === "undefined") {
+if (isBrowser) {
     lsys_load = function(L, path, seeglb) {
         path = to_uristring(path);
         let xhr = new XMLHttpRequest();
@@ -195,7 +199,7 @@ const noenv = function(L) {
 };
 
 let readable;
-if (typeof process !== "undefined") { // Only with Node
+if (isNode) { // Only with Node
     const fs = require('fs');
 
     readable = function(filename) {
@@ -270,7 +274,7 @@ const ll_loadlib = function(L) {
 };
 
 const env = (function() {
-    if (typeof process !== "undefined") {
+    if (isNode) {
         /* node */
         return process.env;
     } else {

--- a/src/loslib.js
+++ b/src/loslib.js
@@ -46,6 +46,9 @@ const {
     to_jsstring,
     to_luastring
 } = require("./fengaricore.js");
+const {
+    isBrowser
+} = require("./isnode.js");
 
 /* options for ANSI C 89 (only 1-char options) */
 // const L_STRFTIMEC89 = to_luastring("aAbBcdHIjmMpSUwWxXyYZ%");
@@ -477,7 +480,7 @@ const syslib = {
     "time": os_time
 };
 
-if (typeof process === "undefined") {
+if (isBrowser) {
     syslib.clock = function(L) {
         lua_pushnumber(L, performance.now()/1000);
         return 1;

--- a/src/luaconf.js
+++ b/src/luaconf.js
@@ -7,6 +7,9 @@ const {
     LUA_VERSION_MINOR,
     to_luastring
 } = require('./defs.js');
+const {
+    isBrowser
+} = require("./isnode.js");
 
 /*
 ** LUA_PATH_SEP is the character that separates templates in a path.
@@ -36,7 +39,7 @@ module.exports.LUA_EXEC_DIR = LUA_EXEC_DIR;
 const LUA_VDIR = LUA_VERSION_MAJOR + "." + LUA_VERSION_MINOR;
 module.exports.LUA_VDIR = LUA_VDIR;
 
-if (typeof process === "undefined") {
+if (isBrowser) {
     const LUA_DIRSEP = "/";
     module.exports.LUA_DIRSEP = LUA_DIRSEP;
 

--- a/src/lualib.js
+++ b/src/lualib.js
@@ -4,6 +4,9 @@ const {
     LUA_VERSION_MAJOR,
     LUA_VERSION_MINOR
 } = require("./lua.js");
+const {
+    isNode
+} = require("./isnode.js");
 
 const LUA_VERSUFFIX = "_" + LUA_VERSION_MAJOR + "_" + LUA_VERSION_MINOR;
 module.exports.LUA_VERSUFFIX = LUA_VERSUFFIX;
@@ -20,7 +23,7 @@ const LUA_TABLIBNAME = "table";
 module.exports.LUA_TABLIBNAME = LUA_TABLIBNAME;
 module.exports.luaopen_table = require("./ltablib.js").luaopen_table;
 
-if (typeof process !== "undefined") {
+if (isNode) {
     const LUA_IOLIBNAME = "io";
     module.exports.LUA_IOLIBNAME = LUA_IOLIBNAME;
     module.exports.luaopen_io = require("./liolib.js").luaopen_io;


### PR DESCRIPTION
**Reviewer Note:**

I'm mostly just starting out on my Node/Webpack/JS/* journey. If there is a blatant misunderstanding of the inner workings of Node, Webpack, or anything related to them, please be gentle with me.

**What is being fixed?**

The issue is described nicely in #156. Basically, when being bundled through Webpack, Fengari would think that it's running in a Node context (because Webpack sets a global `process` variable, which Fengari checks for in a bunch of places.) This would result in Fengari trying to load Node-specific code, which, of course, fails in a Webpack bundle intended for the web.

**How is it fixed?**

I've extracted the expression that determines whether Fengari is running in a node environment into a separate module and changed the various instances where Fengari checked for Node (or non-Node) environments to make use of this module. I've also smartened up the expression slightly.

At its core, the change is the following:

``` js
/* NEW */
((typeof process === "undefined") || process.browser)

/* OLD */
(typeof process === "undefined")
```

**How is it tested?**

I didn't find any tests for the existing behavior and didn't feel like adding a test for this change would provide much value, but I did confirm that this works in my own project.