### PR TITLE
Fix usage of wrong string type in os.execute

### DIFF
--- a/src/loslib.js
+++ b/src/loslib.js
@@ -560,6 +560,7 @@ if (typeof process === "undefined") {
     syslib.execute = function(L) {
         let cmd = luaL_optstring(L, 1, null);
         if (cmd !== null) {
+            cmd = to_jsstring(cmd);
             try {
                 child_process.execSync(
                     cmd,


### PR DESCRIPTION
Hello there,

I noticed that os.execute is currently broken (tested with node v15.0.1).
The string fed into the implementation is actually a lua string (passed as an Uint8Array).
This needs to be converted to a normal JS string, as otherwise, `exec` will reject the input with the following error message:

```
The "file" argument must be of type string. Received an instance of Uint8Array
```

Here is a quick&dirty sample script to test this:

```
const {lauxlib, lua, lualib, to_jsstring, to_luastring} = require("fengari");

let L = lauxlib.luaL_newstate();
lualib.luaL_openlibs(L);

const luaSource = to_luastring("return os.execute('hostname')");

const exitCode = lauxlib.luaL_dostring(L, luaSource);

if (exitCode !== 0) {
    const errorMessage = lua.lua_tostring(L, -1);
    console.log("Error:", to_jsstring(errorMessage));
    return;
}

console.log(to_jsstring(lua.lua_tostring(L, -1)));
```

With the proposed fix, it will output the hostname correctly.